### PR TITLE
Add https://pre-commit.com configuration

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,7 @@
+-   id: import-linter
+    name: import-linter
+    description: Import Linter allows you to define and enforce rules for the internal and external imports within your Python project.
+    entry: lint-imports
+    language: python
+    types: [python]
+    pass_filenames: false


### PR DESCRIPTION
This allows one to use `import-linter` using the [pre-commit] framework

One would use a configuration such as:

```yaml
-   repo: https://github.com/seddonym/import-linter
    rev: ''  # fill in with sha / tag
    hooks:
    -   import-linter
```

[pre-commit]: https://pre-commit.com