### PR TITLE
Less fakegraph

### DIFF
--- a/tests/adapters/building.py
+++ b/tests/adapters/building.py
@@ -3,10 +3,16 @@ from importlinter.domain.ports.graph import ImportGraph
 
 
 class FakeGraphBuilder(GraphBuilder):
+    """
+    Graph builder that allows you to specify the graph ahead of time.
+
+    To use, call inject_graph with the graph you wish to inject, ahead
+    of when the builder would be called.
+    """
     def build(
         self, root_package_name: str, include_external_packages: bool = False
     ) -> ImportGraph:
         return self._graph
 
-    def set_graph(self, graph: ImportGraph) -> None:
+    def inject_graph(self, graph: ImportGraph) -> None:
         self._graph = graph

--- a/tests/unit/application/test_use_cases.py
+++ b/tests/unit/application/test_use_cases.py
@@ -1,7 +1,7 @@
 import string
 from typing import Any, Dict, List, Optional
 
-from grimp.adaptors.graph import ImportGraph
+from grimp.adaptors.graph import ImportGraph  # type: ignore
 from importlinter.application.app_config import settings
 from importlinter.application.use_cases import FAILURE, SUCCESS, lint_imports
 from importlinter.application.user_options import UserOptions

--- a/tests/unit/application/test_use_cases.py
+++ b/tests/unit/application/test_use_cases.py
@@ -214,4 +214,4 @@ class TestCheckContractsAndPrintReport:
         )
         if graph is None:
             graph = FakeGraph(root_package_name="mypackage", module_count=23, import_count=44)
-        settings.GRAPH_BUILDER.set_graph(graph)
+        settings.GRAPH_BUILDER.inject_graph(graph)

--- a/tests/unit/contracts/test_independence.py
+++ b/tests/unit/contracts/test_independence.py
@@ -1,9 +1,9 @@
 import pytest
-
 from grimp.adaptors.graph import ImportGraph
 from importlinter.application.app_config import settings
 from importlinter.contracts.independence import IndependenceContract
 from importlinter.domain.contract import ContractCheck
+
 from tests.adapters.graph import FakeGraph
 from tests.adapters.printing import FakePrinter
 
@@ -256,22 +256,13 @@ def test_ignore_imports(ignore_imports, is_kept):
     graph = ImportGraph()
     graph.add_module("mypackage")
     graph.add_import(
-        importer="mypackage.a",
-        imported="mypackage.irrelevant",
-        line_number=1,
-        line_contents="-",
+        importer="mypackage.a", imported="mypackage.irrelevant", line_number=1, line_contents="-"
     )
     graph.add_import(
-        importer="mypackage.a",
-        imported="mypackage.indirect",
-        line_number=1,
-        line_contents="-",
+        importer="mypackage.a", imported="mypackage.indirect", line_number=1, line_contents="-"
     )
     graph.add_import(
-        importer = "mypackage.indirect",
-        imported = "mypackage.b",
-        line_number = 1,
-        line_contents = "-",
+        importer="mypackage.indirect", imported="mypackage.b", line_number=1, line_contents="-"
     )
     contract = IndependenceContract(
         name="Independence contract",

--- a/tests/unit/contracts/test_independence.py
+++ b/tests/unit/contracts/test_independence.py
@@ -1,5 +1,6 @@
 import pytest
 
+from grimp.adaptors.graph import ImportGraph
 from importlinter.application.app_config import settings
 from importlinter.contracts.independence import IndependenceContract
 from importlinter.domain.contract import ContractCheck
@@ -372,7 +373,9 @@ def test_render_broken_contract():
 
 
 def test_missing_module():
-    graph = FakeGraph(root_package_name="mypackage", all_modules=["mypackage", "mypackage.foo"])
+    graph = ImportGraph()
+    for module in ("mypackage", "mypackage.foo"):
+        graph.add_module(module)
 
     contract = IndependenceContract(
         name="Independence contract",

--- a/tests/unit/contracts/test_independence.py
+++ b/tests/unit/contracts/test_independence.py
@@ -1,5 +1,5 @@
 import pytest
-from grimp.adaptors.graph import ImportGraph
+from grimp.adaptors.graph import ImportGraph  # type: ignore
 from importlinter.application.app_config import settings
 from importlinter.contracts.independence import IndependenceContract
 from importlinter.domain.contract import ContractCheck

--- a/tests/unit/contracts/test_independence.py
+++ b/tests/unit/contracts/test_independence.py
@@ -253,30 +253,25 @@ def test_independence_contract(shortest_chains, expected_invalid_chains):
     ),
 )
 def test_ignore_imports(ignore_imports, is_kept):
-    graph = FakeGraph(
-        root_package_name="mypackage",
-        import_details=[
-            {
-                "importer": "mypackage.a",
-                "imported": "mypackage.irrelevant",
-                "line_number": 1,
-                "line_contents": "-",
-            },
-            {
-                "importer": "mypackage.a",
-                "imported": "mypackage.indirect",
-                "line_number": 1,
-                "line_contents": "-",
-            },
-            {
-                "importer": "mypackage.indirect",
-                "imported": "mypackage.b",
-                "line_number": 1,
-                "line_contents": "-",
-            },
-        ],
-        shortest_chains={("a", "b"): ("a", "indirect", "b")},
-        all_modules=["mypackage", "mypackage.a", "mypackage.b", "mypackage.indirect"],
+    graph = ImportGraph()
+    graph.add_module("mypackage")
+    graph.add_import(
+        importer="mypackage.a",
+        imported="mypackage.irrelevant",
+        line_number=1,
+        line_contents="-",
+    )
+    graph.add_import(
+        importer="mypackage.a",
+        imported="mypackage.indirect",
+        line_number=1,
+        line_contents="-",
+    )
+    graph.add_import(
+        importer = "mypackage.indirect",
+        imported = "mypackage.b",
+        line_number = 1,
+        line_contents = "-",
     )
     contract = IndependenceContract(
         name="Independence contract",

--- a/tests/unit/contracts/test_layers.py
+++ b/tests/unit/contracts/test_layers.py
@@ -191,14 +191,8 @@ def test_layer_contract_multiple_containers(shortest_chains, is_kept):
 
 
 def test_layer_contract_populates_metadata():
-    graph = FakeGraph(
-        root_package_name="mypackage",
-        descendants={
-            "high": {"green", "blue", "yellow", "yellow.alpha"},
-            "medium": {"orange", "red", "orange.beta"},
-            "low": {"black", "white", "white.gamma"},
-        },
-        all_modules=[
+    graph = ImportGraph()
+    for module in (
             "mypackage",
             "mypackage.high",
             "mypackage.high.green",
@@ -213,62 +207,50 @@ def test_layer_contract_populates_metadata():
             "mypackage.low.black",
             "mypackage.low.white",
             "mypackage.low.white.gamma",
-        ],
-        shortest_chains={
-            ("low.white.gamma", "high.yellow.alpha"): (
-                "low.white.gamma",
-                "utils.foo",
-                "utils.bar",
-                "high.yellow.alpha",
-            ),
-            ("medium.orange.beta", "high.blue"): ("medium.orange.beta", "high.blue"),
-            ("low.black", "medium.red"): ("low.black", "utils.baz", "medium.red"),
-        },
-        import_details=[
-            {
-                "importer": "mypackage.low.white.gamma",
-                "imported": "mypackage.utils.foo",
-                "line_number": 3,
-                "line_contents": "",
-            },
-            {
-                "importer": "mypackage.utils.foo",
-                "imported": "mypackage.utils.bar",
-                "line_number": 1,
-                "line_contents": "",
-            },
-            {
-                "importer": "mypackage.utils.foo",
-                "imported": "mypackage.utils.bar",
-                "line_number": 101,
-                "line_contents": "",
-            },
-            {
-                "importer": "mypackage.utils.bar",
-                "imported": "mypackage.high.yellow.alpha",
-                "line_number": 13,
-                "line_contents": "",
-            },
-            {
-                "importer": "mypackage.medium.orange.beta",
-                "imported": "mypackage.high.blue",
-                "line_number": 2,
-                "line_contents": "",
-            },
-            {
-                "importer": "mypackage.low.black",
-                "imported": "mypackage.utils.baz",
-                "line_number": 2,
-                "line_contents": "",
-            },
-            {
-                "importer": "mypackage.utils.baz",
-                "imported": "mypackage.medium.red",
-                "line_number": 3,
-                "line_contents": "",
-            },
-        ],
-    )
+    ):
+        graph.add_module(module)
+    graph.add_import(
+        importer="mypackage.low.white.gamma",
+        imported="mypackage.utils.foo",
+        line_number=3,
+        line_contents="-",
+    ),
+    graph.add_import(
+        importer="mypackage.utils.foo",
+        imported="mypackage.utils.bar",
+        line_number=1,
+        line_contents="-",
+    ),
+    graph.add_import(
+        importer="mypackage.utils.foo",
+        imported="mypackage.utils.bar",
+        line_number=101,
+        line_contents="-",
+    ),
+    graph.add_import(
+        importer="mypackage.utils.bar",
+        imported="mypackage.high.yellow.alpha",
+        line_number=13,
+        line_contents="-",
+    ),
+    graph.add_import(
+        importer="mypackage.medium.orange.beta",
+        imported="mypackage.high.blue",
+        line_number=2,
+        line_contents="-",
+    ),
+    graph.add_import(
+        importer="mypackage.low.black",
+        imported="mypackage.utils.baz",
+        line_number=2,
+        line_contents="-",
+    ),
+    graph.add_import(
+        importer="mypackage.utils.baz",
+        imported="mypackage.medium.red",
+        line_number=3,
+        line_contents="-",
+    ),
 
     contract = LayersContract(
         name="Layer contract",

--- a/tests/unit/contracts/test_layers.py
+++ b/tests/unit/contracts/test_layers.py
@@ -1,5 +1,5 @@
 import pytest
-from grimp.adaptors.graph import ImportGraph
+from grimp.adaptors.graph import ImportGraph  # type: ignore
 from importlinter.application.app_config import settings
 from importlinter.contracts.layers import LayersContract
 from importlinter.domain.contract import ContractCheck

--- a/tests/unit/contracts/test_layers.py
+++ b/tests/unit/contracts/test_layers.py
@@ -467,17 +467,16 @@ def test_ignore_imports(ignore_imports, invalid_chain):
     "include_parentheses, should_raise_exception", ((False, True), (True, False))
 )
 def test_optional_layers(include_parentheses, should_raise_exception):
-    graph = FakeGraph(
-        root_package_name="mypackage",
-        all_modules=[
-            "mypackage",
-            "mypackage.foo",
-            "mypackage.foo.high",
-            "mypackage.foo.high.blue",
-            "mypackage.foo.low",
-            "mypackage.foo.low.alpha",
-        ],
-    )
+    graph = ImportGraph()
+    for module in (
+        "mypackage",
+        "mypackage.foo",
+        "mypackage.foo.high",
+        "mypackage.foo.high.blue",
+        "mypackage.foo.low",
+        "mypackage.foo.low.alpha",
+    ):
+        graph.add_module(module)
 
     contract = LayersContract(
         name="Layer contract",

--- a/tests/unit/contracts/test_layers.py
+++ b/tests/unit/contracts/test_layers.py
@@ -1,9 +1,10 @@
 import pytest
-
+from grimp.adaptors.graph import ImportGraph
 from importlinter.application.app_config import settings
 from importlinter.contracts.layers import LayersContract
 from importlinter.domain.contract import ContractCheck
 from importlinter.domain.helpers import MissingImport
+
 from tests.adapters.graph import FakeGraph
 from tests.adapters.printing import FakePrinter
 
@@ -610,18 +611,17 @@ def test_render_broken_contract():
     ),
 )
 def test_invalid_container(container):
-    graph = FakeGraph(
-        root_package_name="mypackage",
-        all_modules=[
-            "mypackage",
-            "mypackage.foo",
-            "mypackage.foo.high",
-            "mypackage.foo.medium",
-            "mypackage.foo.low",
-            "notinpackage",
-            "mypackagebeginscorrectly",
-        ],
-    )
+    graph = ImportGraph()
+    for module in (
+        "mypackage",
+        "mypackage.foo",
+        "mypackage.foo.high",
+        "mypackage.foo.medium",
+        "mypackage.foo.low",
+        "notinpackage",
+        "mypackagebeginscorrectly",
+    ):
+        graph.add_module(module)
 
     contract = LayersContract(
         name="Layer contract",


### PR DESCRIPTION
FakeGraph is a needless abstraction from Grimp's ImportGraph - it's become a complicated class in its own right, better just to use the graph class we rely on.

This PR does some of the work in removing the FakeGraph.