### PR TITLE
Add compatibility for Python 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,11 @@ matrix:
       sudo: required
       env:
         - TOXENV=py37,report
+    - python: '3.8-dev'
+      dist: xenial
+      sudo: required
+      env:
+        - TOXENV=py38,report
 before_install:
   - python --version
   - uname -a

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -51,3 +51,8 @@ Changelog
 
 * Allow multiple root packages.
 * Make containers optional in Layers contracts.
+
+latest
+------
+
+* Officially support Python 3.8.

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ setup(
         "Programming Language :: Python",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: Implementation :: CPython",
         "Topic :: Utilities",
     ],

--- a/tests/adapters/filesystem.py
+++ b/tests/adapters/filesystem.py
@@ -82,7 +82,7 @@ class FakeFileSystem(ports.FileSystem):
 
         yamlified_string = "\n".join(yamlified_lines)
 
-        return yaml.load(yamlified_string)
+        return yaml.safe_load(yamlified_string)
 
     def _dedent(self, lines: List[str]) -> List[str]:
         """

--- a/tox.ini
+++ b/tox.ini
@@ -3,13 +3,14 @@ envlist =
     clean,
     check,
     docs,
-    {py36,py37},
+    {py36,py37,py38},
     report
 
 [testenv]
 basepython =
     py36: {env:TOXPYTHON:python3.6}
     py37: {env:TOXPYTHON:python3.7}
+    py38: {env:TOXPYTHON:python3.8}
     {clean,check,docs,report}: {env:TOXPYTHON:python3}
 setenv =
     PYTHONPATH={toxinidir}/tests

--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,7 @@ deps =
     pytest==3.10.0
     pytest-travis-fold==1.3.0
     pytest-cov==2.6.0
-    PyYAML==3.13
+    PyYAML==5.1.2
 commands =
     {posargs:pytest --cov --cov-report=term-missing -vv tests}
 


### PR DESCRIPTION
This currently uses python3.8-dev, wait until release and update before merging.