### PR TITLE
Upgrade grimp to 1.2.2

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -81,3 +81,9 @@ Changelog
 ---
 
 * Bring 1.1 out of beta.
+
+
+latest
+------
+
+* Upgrade Grimp to 1.2.2.

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
         "Programming Language :: Python :: Implementation :: CPython",
         "Topic :: Utilities",
     ],
-    install_requires=["click>=6,<8", "grimp>=1.2,<2"],
+    install_requires=["click>=6,<8", "grimp>=1.2.2,<2"],
     entry_points={
         "console_scripts": ["lint-imports = importlinter.cli:lint_imports_command"]
     },


### PR DESCRIPTION
This results in more informative syntax error reporting.