### PR TITLE
Improve changelog

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,61 +1,23 @@
 Changelog
 =========
 
-1.0a1 (2019-1-27)
------------------
-
-* Release blank project on PyPI.
-
-
-1.0a2 (2019-3-26)
------------------
-
-* First usable alpha release.
-
-
-1.0a3 (2019-3-27)
------------------
-
-* Include the ability to build the graph with external packages.
-
-
-1.0b1 (2019-4-6)
+1.2 (2020-09-23)
 ----------------
 
-* Improve error handling of modules/containers not in the graph.
-* Return the exit code correctly.
-* Run lint-imports on Import Linter itself.
-* Allow single values in ListField.
+* Upgrade Grimp to 1.2.2.
+* Add SetField
+* Use a SetField for ignore_imports options
+* Add support for non `\w` characters in import exceptions
 
-
-1.0b2 (2019-4-16)
------------------
-
-* Update to Grimp v1.0b9, fixing error with using importlib.util.find_spec.
-
-
-1.0b3 (2019-5-15)
------------------
-
-* Update to Grimp v1.0b10, fixing Windows incompatibility.
-
-1.0b4 (2019-7-3)
+1.1 (2020-06-29)
 ----------------
 
-* Add https://pre-commit.com configuration.
-* Use find_shortest_chains instead of find_shortest_chain on the Grimp import graph.
-* Add Forbidden Modules contract type.
+* Bring 1.1 out of beta.
 
-1.0b5 (2019-10-5)
------------------
+1.1b2 (2019-11-27)
+------------------
 
-* Allow multiple root packages.
-* Make containers optional in Layers contracts.
-
-1.0 (2019-17-10)
-----------------
-
-* Officially support Python 3.8.
+* Update to Grimp v1.2, significantly increasing speed of building the graph.
 
 1.1b1 (2019-11-24)
 ------------------
@@ -72,21 +34,53 @@ Changelog
   chain is repeatedly popped from the graph until no more chains remain. This results in more comprehensive results,
   and at significantly increased speed.
 
-1.1b2 (2019-11-27)
+1.0 (2019-17-10)
+----------------
+
+* Officially support Python 3.8.
+
+1.0b5 (2019-10-05)
 ------------------
 
-* Update to Grimp v1.2, significantly increasing speed of building the graph.
+* Allow multiple root packages.
+* Make containers optional in Layers contracts.
 
-1.1 (2020-6-29)
----------------
+1.0b4 (2019-07-03)
+------------------
 
-* Bring 1.1 out of beta.
+* Add https://pre-commit.com configuration.
+* Use find_shortest_chains instead of find_shortest_chain on the Grimp import graph.
+* Add Forbidden Modules contract type.
 
+1.0b3 (2019-05-15)
+------------------
 
-1.2 (2020-9-23)
----------------
+* Update to Grimp v1.0b10, fixing Windows incompatibility.
 
-* Upgrade Grimp to 1.2.2.
-* Add SetField
-* Use a SetField for ignore_imports options
-* Add support for non `\w` characters in import exceptions
+1.0b2 (2019-04-16)
+------------------
+
+* Update to Grimp v1.0b9, fixing error with using importlib.util.find_spec.
+
+1.0b1 (2019-04-06)
+------------------
+
+* Improve error handling of modules/containers not in the graph.
+* Return the exit code correctly.
+* Run lint-imports on Import Linter itself.
+* Allow single values in ListField.
+
+1.0a3 (2019-03-27)
+------------------
+
+* Include the ability to build the graph with external packages.
+
+1.0a2 (2019-03-26)
+------------------
+
+* First usable alpha release.
+
+1.0a1 (2019-01-27)
+------------------
+
+* Release blank project on PyPI.


### PR DESCRIPTION
* Reverse order so latest release at the top, which seems to be the de facto standard
* Use full ISO datetimes to reduce potential ambiguity