### PR TITLE
Add exhaustiveness to layers

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -3,6 +3,9 @@ ignore = E731, E203, W503
 max-line-length = 100
 exclude = */migrations/*, tests/assets/*
 
+[mypy]
+warn_unused_ignores = True
+
 [mypy-pytest]
 ignore_missing_imports = True
 

--- a/src/importlinter/application/use_cases.py
+++ b/src/importlinter/application/use_cases.py
@@ -97,15 +97,18 @@ def _build_graph(
 def _build_report(graph: ImportGraph, user_options: UserOptions) -> Report:
     report = Report(graph=graph)
     for contract_options in user_options.contracts_options:
-        contract_class = registry.get_contract_class(contract_options["type"])
+        name = contract_options.pop("name")
+        type_ = contract_options.pop("type")
+
+        contract_class = registry.get_contract_class(type_)
         try:
             contract = contract_class(
-                name=contract_options["name"],
+                name=name,
                 session_options=user_options.session_options,
                 contract_options=contract_options,
             )
         except InvalidContractOptions as e:
-            report.add_invalid_contract_options(contract_options["name"], e)
+            report.add_invalid_contract_options(name, e)
             return report
 
         # Make a copy so that contracts can mutate the graph without affecting

--- a/src/importlinter/contracts/layers.py
+++ b/src/importlinter/contracts/layers.py
@@ -196,7 +196,7 @@ class LayersContract(Contract):
             module_in_higher_layer, module_in_lower_layer, container
         """
         # If there are no containers, we still want to run the loop once.
-        quasi_containers = self.containers or [None]  # type: ignore
+        quasi_containers = self.containers or [None]
 
         for container in quasi_containers:  # type: ignore
             for index, higher_layer in enumerate(self.layers):  # type: ignore
@@ -398,7 +398,7 @@ class LayersContract(Contract):
         return collapsed_chains
 
     def _remove_other_layers(self, graph, container, layers_to_preserve):
-        for index, layer in enumerate(self.layers):  # type: ignore
+        for index, layer in enumerate(self.layers):
             candidate_layer = self._module_from_layer(layer, container)
             if candidate_layer.name in graph.modules and candidate_layer not in layers_to_preserve:
                 self._remove_layer(graph, layer_package=candidate_layer)

--- a/src/importlinter/domain/contract.py
+++ b/src/importlinter/domain/contract.py
@@ -32,7 +32,11 @@ class Contract(abc.ABC):
                 if field.required:
                     errors[field_name] = "This is a required field."
                 else:
-                    setattr(self, field_name, None)
+                    # field.default is None if it isn't declared
+                    if callable(field.default):
+                        setattr(self, field_name, field.default())
+                    else:
+                        setattr(self, field_name, field.default)
                 continue
 
             try:

--- a/src/importlinter/domain/fields.py
+++ b/src/importlinter/domain/fields.py
@@ -43,6 +43,23 @@ class StringField(Field):
         return str(raw_data)
 
 
+class BooleanField(Field):
+    """
+    A field for single values of booleans.
+    """
+
+    def parse(self, raw_data: Union[str, List]) -> bool:
+        if isinstance(raw_data, list):
+            raise ValidationError("Expected a single value, got multiple values.")
+
+        if raw_data.lower() == "true":
+            return True
+        elif raw_data.lower() == "false":
+            return False
+        else:
+            raise ValidationError(f"Could not parse a boolean from '{raw_data}'")
+
+
 class BaseMultipleValueField(Field):
     """
     An abstract field for multiple values of any type.

--- a/src/importlinter/domain/fields.py
+++ b/src/importlinter/domain/fields.py
@@ -1,5 +1,5 @@
 import abc
-from typing import Generic, Iterable, List, Set, TypeVar, Union
+from typing import Generic, Iterable, List, Optional, Set, TypeVar, Union
 
 from importlinter.domain.imports import DirectImport, Module
 
@@ -18,8 +18,9 @@ class Field(Generic[FieldValue], abc.ABC):
     Designed to be subclassed, Fields should override the ``parse`` method.
     """
 
-    def __init__(self, required: bool = True) -> None:
+    def __init__(self, required: bool = True, default: Optional[FieldValue] = None) -> None:
         self.required = required
+        self.default = default
 
     @abc.abstractmethod
     def parse(self, raw_data: Union[str, List[str]]) -> FieldValue:

--- a/src/importlinter/domain/ports/graph.py
+++ b/src/importlinter/domain/ports/graph.py
@@ -19,6 +19,10 @@ class ImportGraph(abc.ABC):
         raise NotImplementedError
 
     @abc.abstractmethod
+    def find_children(self, module: str) -> Set[str]:
+        raise NotImplementedError
+
+    @abc.abstractmethod
     def find_descendants(self, module: str) -> Set[str]:
         raise NotImplementedError
 

--- a/tests/unit/domain/test_contract.py
+++ b/tests/unit/domain/test_contract.py
@@ -65,6 +65,27 @@ def test_contract_validation(contract_options, expected_errors):
         assert False, "Did not raise InvalidContractOptions."  # pragma: nocover
 
 
+def test_default_values_are_used_if_values_not_provided():
+    class ContractWithDefaults(Contract):
+        no_default = MyField(required=False)
+        static_default = MyField(required=False, default="valid value")
+        dynamic_default = MyField(required=False, default=list)
+
+        def check(self, *args, **kwargs):
+            raise NotImplementedError
+
+        def render_broken_contract(self, *args, **kwargs):
+            raise NotImplementedError
+
+    contract_kwargs = dict(name="My contract", session_options={}, contract_options={})
+
+    contract = ContractWithDefaults(**contract_kwargs)
+
+    assert contract.no_default is None
+    assert contract.static_default == "valid value"
+    assert contract.dynamic_default == []
+
+
 class TestContractRegistry:
     @pytest.mark.parametrize(
         "name, expected_result",

--- a/tests/unit/domain/test_contract.py
+++ b/tests/unit/domain/test_contract.py
@@ -44,6 +44,10 @@ class AnotherContract(Contract):
         ),
         ({}, {"foo": "This is a required field."}),  # No data.
         ({"foo": "something invalid"}, {"foo": '"something invalid" is not a valid value.'}),
+        (
+            {"foo": "Good morning!", "some invalid field": "some value"},
+            {"some invalid field": "This field does not exist for this contract."},
+        ),
     ),
 )
 def test_contract_validation(contract_options, expected_errors):

--- a/tests/unit/domain/test_fields.py
+++ b/tests/unit/domain/test_fields.py
@@ -3,6 +3,7 @@ from typing import Any, Dict, Optional, Type
 import pytest
 
 from importlinter.domain.fields import (
+    BooleanField,
     DirectImportField,
     Field,
     ListField,
@@ -42,6 +43,22 @@ class BaseFieldTest:
 )
 class TestStringField(BaseFieldTest):
     field_class = StringField
+
+
+@pytest.mark.parametrize(
+    "raw_data, expected_value",
+    (
+        ("true", True),
+        ("fAlSe", False),
+        ("bananas", ValidationError("Could not parse a boolean from 'bananas'")),
+        (
+            ["one", "two", "three"],
+            ValidationError("Expected a single value, got multiple values."),
+        ),
+    ),
+)
+class TestBooleanField(BaseFieldTest):
+    field_class = BooleanField
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR adds the concept of "exhaustiveness" to layers contracts. An exhaustive contract is one where the contract definition is guaranteed to specify all layers that may exist in the containing modules. Users can also ignore submodules from the exhaustiveness checks if that flexibility is needed.

The aim of exhaustive contracts is to make it impossible to add a new layer into a container without considering where it fits in the hierachy.

The PR contains various bits of housekeeping that I did while trying to get a clean `tox` run on my local machine - I can drop them if preferred.