### PR TITLE
Forbidden contract: Fix swapped logic in allow_indirect_imports

### DIFF
--- a/src/importlinter/contracts/forbidden.py
+++ b/src/importlinter/contracts/forbidden.py
@@ -52,6 +52,10 @@ class ForbiddenContract(Contract):
                 }
 
                 if str(self.allow_indirect_imports).lower() == "true":
+                    chains = graph.find_shortest_chains(
+                        importer=source_module.name, imported=forbidden_module.name
+                    )
+                else:
                     chains = {
                         cast(
                             Tuple[str, ...],
@@ -61,10 +65,6 @@ class ForbiddenContract(Contract):
                             importer=source_module.name, imported=forbidden_module.name
                         )
                     }
-                else:
-                    chains = graph.find_shortest_chains(
-                        importer=source_module.name, imported=forbidden_module.name
-                    )
                 if chains:
                     is_kept = False
                     for chain in chains:

--- a/tests/assets/testpackage/.externalbrokencontract.ini
+++ b/tests/assets/testpackage/.externalbrokencontract.ini
@@ -6,5 +6,6 @@ include_external_packages = True
 [importlinter:contract:one]
 name=External kept contract
 type=forbidden
+allow_indirect_imports=true
 source_modules=testpackage.high.blue
 forbidden_modules=pytest


### PR DESCRIPTION
Per the referece documentation of Grimp
`ImportGraph.find_shortest_chains` and `ImportGraph.get_import_details()`
if seems like the first one should be used when `allow_indirect_imports`
is true and the latter when it's not.

Updated unit test asserts accordingly.