### PR TITLE
Allow Click 8.x.x

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
         "Topic :: Utilities",
     ],
     python_requires=">=3.6",
-    install_requires=["click>=6,<8", "grimp>=1.2.3,<2"],
+    install_requires=["click>=6,<9", "grimp>=1.2.3,<2"],
     entry_points={
         "console_scripts": ["lint-imports = importlinter.cli:lint_imports_command"]
     },


### PR DESCRIPTION
Click 8.0.0 is released 2021-05-12 (and 8.0.1 later). It includes type annotations and other useful features. However, import-linter restricts the version to `<8`, which breaks any environment that would like to use Click 8.x.x — despite it works quite fine with this new version.

This PR allows Click 8.x.x to be used and raises the version limit to 9.x.x (not yet existent).
