### PR TITLE
Use `extras_require`, not unknown `extra_requires`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
     ],
     python_requires=">=3.6",
     install_requires=["click>=6,<9", "grimp>=1.2.3,<2"],
-    extra_requires={"toml": ["toml"]},
+    extras_require={"toml": ["toml"]},
     entry_points={
         "console_scripts": ["lint-imports = importlinter.cli:lint_imports_command"]
     },


### PR DESCRIPTION
Came across the below error while trawling through `pip install` logs for an unrelated issue:

```bash
    /miniconda/envs/customerone/lib/python3.7/distutils/dist.py:274: UserWarning: Unknown distribution option: 'extra_requires'
```