### PR TITLE
Fix TOML booleans

### DIFF
--- a/src/importlinter/adapters/user_options.py
+++ b/src/importlinter/adapters/user_options.py
@@ -98,4 +98,14 @@ class TomlFileUserOptionReader(AbstractUserOptionReader):
             return None
 
         contracts = session_options.pop("contracts", [])
+
+        self._normalize_booleans(session_options)
+        for contract in contracts:
+            self._normalize_booleans(contract)
+
         return UserOptions(session_options=session_options, contracts_options=contracts)
+
+    def _normalize_booleans(self, data: dict) -> None:
+        for key, value in data.items():
+            if isinstance(value, bool):
+                data[key] = str(value)

--- a/tests/assets/testpackage/.externalkeptcontract.toml
+++ b/tests/assets/testpackage/.externalkeptcontract.toml
@@ -1,8 +1,8 @@
-[tools.importlinter]
+[tool.importlinter]
 root_package = "testpackage"
 include_external_packages = true
 
-[[tools.importlinter.contracts]]
+[[tool.importlinter.contracts]]
 name = "External kept contract"
 type = "forbidden"
 source_modules = ["testpackage.high.blue"]

--- a/tests/assets/testpackage/.externalkeptcontract.toml
+++ b/tests/assets/testpackage/.externalkeptcontract.toml
@@ -1,0 +1,9 @@
+[tools.importlinter]
+root_package = "testpackage"
+include_external_packages = true
+
+[[tools.importlinter.contracts]]
+name = "External kept contract"
+type = "forbidden"
+source_modules = ["testpackage.high.blue"]
+forbidden_modules = ["sqlalchemy"]

--- a/tests/functional/test_lint_imports.py
+++ b/tests/functional/test_lint_imports.py
@@ -28,6 +28,12 @@ multipleroots_directory = os.path.join(os.path.dirname(__file__), "..", "assets"
             marks=pytest.mark.toml_installed,
         ),
         (testpackage_directory, ".externalkeptcontract.ini", cli.EXIT_STATUS_SUCCESS),
+        pytest.param(
+            testpackage_directory,
+            ".externalkeptcontract.toml",
+            cli.EXIT_STATUS_SUCCESS,
+            marks=pytest.mark.toml_installed,
+        ),
         (testpackage_directory, ".externalbrokencontract.ini", cli.EXIT_STATUS_ERROR),
         (multipleroots_directory, ".multiplerootskeptcontract.ini", cli.EXIT_STATUS_SUCCESS),
         (multipleroots_directory, ".multiplerootsbrokencontract.ini", cli.EXIT_STATUS_ERROR),

--- a/tests/unit/adapters/test_user_options.py
+++ b/tests/unit/adapters/test_user_options.py
@@ -150,6 +150,7 @@ def test_respects_passed_filename(passed_filename, expected_foo_value):
             """
             [tool.importlinter]
             foo = "hello"
+            include_external_packages = true
 
             [[tool.importlinter.contracts]]
             name = "Contract One"
@@ -166,7 +167,7 @@ def test_respects_passed_filename(passed_filename, expected_foo_value):
             baz = 3
             """,
             UserOptions(
-                session_options={"foo": "hello"},
+                session_options={"foo": "hello", "include_external_packages": "True"},
                 contracts_options=[
                     {
                         "name": "Contract One",


### PR DESCRIPTION
The main application logic assumes, that booleans are passed as strings from the config.
However, TOML supports native booleans which are obviously no strings.

The easiest solution is to translate bools to strings when parsing the TOML.