### PR TITLE
Support wildcards in module ignores (#103)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Changelog
 latest
 ------
 
+* Wildcard support for ignored imports.
 * Convert TOML booleans to strings in UserOptions, to make consistent with INI file parsing.
 
 1.2.4 (2021-08-09)

--- a/docs/contract_types.rst
+++ b/docs/contract_types.rst
@@ -62,10 +62,7 @@ Configuration options:
     - ``forbidden_modules``: A list of modules that should not be imported by the source modules. These may include
       root level external packages (i.e. ``django``, but not ``django.db.models``). If external packages are included,
       the top level configuration must have ``internal_external_packages = True``.
-    - ``ignore_imports``:
-      A list of imports, each in the form ``mypackage.foo.importer -> mypackage.bar.imported``. These imports
-      will be ignored: if the import would cause a contract to be broken, adding it to the list will cause the
-      contract be kept instead. (Optional.)
+    - ``ignore_imports``: See :ref:`Shared options`.
     - ``allow_indirect_imports``: If ``True``, allow indirect imports to forbidden modules without interpreting them
       as a reason to mark the contract broken. (Optional.)
 
@@ -96,10 +93,8 @@ They do this by checking that there are no imports in any direction between the 
 **Configuration options**
 
     - ``modules``: A list of modules/subpackages that should be independent from each other.
-    - ``ignore_imports``:
-      A list of imports, each in the form ``mypackage.foo.importer -> mypackage.bar.imported``. These imports
-      will be ignored: if the import would cause a contract to be broken, adding it to the list will cause the
-      contract be kept instead. (Optional.)
+    - ``ignore_imports``: See :ref:`Shared options`.
+
 
 Layers
 ------
@@ -187,10 +182,8 @@ won't complain.
     - ``containers``:
       List of the parent modules of the layers, as *absolute names* that you could import, such as
       ``mypackage.foo``. (Optional.)
-    - ``ignore_imports``:
-      A list of imports, each in the form ``mypackage.foo.importer -> mypackage.bar.imported``. These imports
-      will be ignored: if the import would cause a contract to be broken, adding it to the list will cause the
-      contract be kept instead. (Optional.)
+    - ``ignore_imports``: See :ref:`Shared options`.
+
 
 
 Custom contract types
@@ -198,3 +191,23 @@ Custom contract types
 
 If none of the built in contract types meets your needs, you can define a custom contract type: see
 :doc:`custom_contract_types`.
+
+
+.. _Shared options:
+
+Options used by multiple contracts
+----------------------------------
+
+- ``ignore_imports``: Optional list of imports, each in the form ``mypackage.foo.importer -> mypackage.bar.imported``.
+  These imports will be ignored: if the import would cause a contract to be broken, adding it to the list will cause the
+  contract be kept instead.
+
+  Wildcards (in the form of ``*``) are supported. These can stand in for a module names, but they do not extend to
+  subpackages.
+
+  Examples:
+
+  - ``mypackage.*``:  matches ``mypackage.foo`` but not ``mypackage.foo.bar``.
+  - ``mypackage.*.baz``: matches ``mypackage.foo.baz`` but not ``mypackage.foo.bar.baz``.
+  - ``mypackage.*.*``: matches ``mypackage.foo.bar`` and ``mypackage.foobar.baz``.
+  - ``mypackage.foo*``: not a valid expression. (The wildcard must replace a whole module name.)

--- a/src/importlinter/contracts/forbidden.py
+++ b/src/importlinter/contracts/forbidden.py
@@ -13,7 +13,7 @@ class ForbiddenContract(Contract):
     Configuration options:
         - source_modules:    A list of Modules that should not import the forbidden modules.
         - forbidden_modules: A list of Modules that should not be imported by the source modules.
-        - ignore_imports:    A set of DirectImports. These imports will be ignored: if the import
+        - ignore_imports:    A set of ImportExpressions. These imports will be ignored if the import
                              would cause a contract to be broken, adding it to the set will cause
                              the contract be kept instead. (Optional.)
         - allow_indirect_imports:  Whether to allow indirect imports to forbidden modules.
@@ -24,14 +24,14 @@ class ForbiddenContract(Contract):
 
     source_modules = fields.ListField(subfield=fields.ModuleField())
     forbidden_modules = fields.ListField(subfield=fields.ModuleField())
-    ignore_imports = fields.SetField(subfield=fields.DirectImportField(), required=False)
+    ignore_imports = fields.SetField(subfield=fields.ImportExpressionField(), required=False)
     allow_indirect_imports = fields.StringField(required=False)
 
     def check(self, graph: ImportGraph) -> ContractCheck:
         is_kept = True
         invalid_chains = []
 
-        helpers.pop_imports(
+        helpers.pop_import_expressions(
             graph, self.ignore_imports if self.ignore_imports else []  # type: ignore
         )
 

--- a/src/importlinter/contracts/independence.py
+++ b/src/importlinter/contracts/independence.py
@@ -16,7 +16,7 @@ class IndependenceContract(Contract):
     Configuration options:
 
         - modules:        A list of Modules that should be independent from each other.
-        - ignore_imports: A set of DirectImports. These imports will be ignored: if the import
+        - ignore_imports: A set of ImportExpressions. These imports will be ignored: if the import
                           would cause a contract to be broken, adding it to the set will cause
                           the contract be kept instead. (Optional.)
     """
@@ -24,13 +24,13 @@ class IndependenceContract(Contract):
     type_name = "independence"
 
     modules = fields.ListField(subfield=fields.ModuleField())
-    ignore_imports = fields.SetField(subfield=fields.DirectImportField(), required=False)
+    ignore_imports = fields.SetField(subfield=fields.ImportExpressionField(), required=False)
 
     def check(self, graph: ImportGraph) -> ContractCheck:
         is_kept = True
         invalid_chains = []
 
-        helpers.pop_imports(
+        helpers.pop_import_expressions(
             graph, self.ignore_imports if self.ignore_imports else []  # type: ignore
         )
 

--- a/src/importlinter/contracts/layers.py
+++ b/src/importlinter/contracts/layers.py
@@ -42,7 +42,7 @@ class LayersContract(Contract):
         - layers:         An ordered list of layers. Each layer is the name of a module relative
                           to its parent package. The order is from higher to lower level layers.
         - containers:     A list of the parent Modules of the layers (optional).
-        - ignore_imports: A set of DirectImports. These imports will be ignored: if the import
+        - ignore_imports: A set of ImportExpressions. These imports will be ignored: if the import
                           would cause a contract to be broken, adding it to the set will cause
                           the contract be kept instead. (Optional.)
     """
@@ -51,14 +51,14 @@ class LayersContract(Contract):
 
     layers = fields.ListField(subfield=LayerField())
     containers = fields.ListField(subfield=fields.StringField(), required=False)
-    ignore_imports = fields.SetField(subfield=fields.DirectImportField(), required=False)
+    ignore_imports = fields.SetField(subfield=fields.ImportExpressionField(), required=False)
 
     def check(self, graph: ImportGraph) -> ContractCheck:
         is_kept = True
         invalid_chains = []
 
         direct_imports_to_ignore = self.ignore_imports if self.ignore_imports else []
-        helpers.pop_imports(graph, direct_imports_to_ignore)  # type: ignore
+        helpers.pop_import_expressions(graph, direct_imports_to_ignore)  # type: ignore
 
         if self.containers:
             self._validate_containers(graph)

--- a/src/importlinter/domain/helpers.py
+++ b/src/importlinter/domain/helpers.py
@@ -1,6 +1,8 @@
-from typing import Dict, Iterable, List, Union
+import itertools
+import re
+from typing import Dict, Iterable, List, Pattern, Set, Tuple, Union, cast
 
-from importlinter.domain.imports import DirectImport
+from importlinter.domain.imports import DirectImport, ImportExpression, Module
 from importlinter.domain.ports.graph import ImportGraph
 
 
@@ -18,7 +20,7 @@ def pop_imports(
         The list of import details that were removed, including any additional metadata.
 
     Raises:
-        MissingImport if the import is not present in the graph.
+        MissingImport if an import is not present in the graph.
     """
     removed_imports: List[Dict[str, Union[str, int]]] = []
     for import_to_remove in imports:
@@ -32,6 +34,57 @@ def pop_imports(
             importer=import_to_remove.importer.name, imported=import_to_remove.imported.name
         )
     return removed_imports
+
+
+def import_expressions_to_imports(
+    graph: ImportGraph, expressions: Iterable[ImportExpression]
+) -> List[DirectImport]:
+    """
+    Returns a list of imports in a graph, given some import expressions.
+
+    Raises:
+        MissingImport if an import is not present in the graph. For a wildcarded import expression,
+        this is raised if there is not at least one match.
+    """
+    imports: Set[DirectImport] = set()
+    for expression in expressions:
+        matched = False
+        for (importer, imported) in _expression_to_modules(expression, graph):
+            import_details = graph.get_import_details(
+                importer=importer.name, imported=imported.name
+            )
+            if import_details:
+                for individual_import_details in import_details:
+                    imports.add(
+                        DirectImport(
+                            importer=Module(cast(str, individual_import_details["importer"])),
+                            imported=Module(cast(str, individual_import_details["imported"])),
+                            line_number=cast(int, individual_import_details["line_number"]),
+                            line_contents=cast(str, individual_import_details["line_contents"]),
+                        )
+                    )
+                matched = True
+        if not matched:
+            raise MissingImport(
+                f"Ignored import expression {expression} didn't match anything in the graph."
+            )
+    return list(imports)
+
+
+def pop_import_expressions(
+    graph: ImportGraph, expressions: Iterable[ImportExpression]
+) -> List[Dict[str, Union[str, int]]]:
+    """
+    Removes any imports matching the supplied import expressions from the graph.
+
+    Returns:
+        The list of imports that were removed, including any additional metadata.
+    Raises:
+        MissingImport if an import is not present in the graph. For a wildcarded import expression,
+        this is raised if there is not at least one match.
+    """
+    imports = import_expressions_to_imports(graph, expressions)
+    return pop_imports(graph, imports)
 
 
 def add_imports(graph: ImportGraph, import_details: List[Dict[str, Union[str, int]]]) -> None:
@@ -55,3 +108,38 @@ def add_imports(graph: ImportGraph, import_details: List[Dict[str, Union[str, in
             line_number=details["line_number"],
             line_contents=details["line_contents"],
         )
+
+
+def _to_pattern(expression: str) -> Pattern:
+    """
+    Function which translates an import expression into a regex pattern.
+    """
+    pattern_parts = []
+    for part in expression.split("."):
+        if "*" == part:
+            pattern_parts.append(part.replace("*", r"[^\.]+"))
+        else:
+            pattern_parts.append(part)
+    return re.compile(r"^" + r"\.".join(pattern_parts) + r"$")
+
+
+def _expression_to_modules(
+    expression: ImportExpression, graph: ImportGraph
+) -> Iterable[Tuple[Module, Module]]:
+    if not expression.has_wildcard_expression():
+        return [(Module(expression.importer), Module(expression.imported))]
+
+    importer = []
+    imported = []
+
+    importer_pattern = _to_pattern(expression.importer)
+    imported_expression = _to_pattern(expression.imported)
+
+    for module in graph.modules:
+
+        if importer_pattern.match(module):
+            importer.append(Module(module))
+        if imported_expression.match(module):
+            imported.append(Module(module))
+
+    return itertools.product(set(importer), set(imported))

--- a/src/importlinter/domain/imports.py
+++ b/src/importlinter/domain/imports.py
@@ -86,3 +86,26 @@ class DirectImport(ValueObject):
 
     def __hash__(self) -> int:
         return hash((str(self), self.line_contents))
+
+
+class ImportExpression(ValueObject):
+    """
+    A user-submitted expression describing an import or set of imports.
+
+    Sets of imports are notated using * wildcards.
+    These wildcards can stand in for a module name or part of a name, but they do
+    not extend to subpackages.
+
+    For example, "mypackage.*" refers to every child subpackage of mypackage.
+    It does not, however, include more distant descendants such as mypackage.foo.bar.
+    """
+
+    def __init__(self, importer: str, imported: str) -> None:
+        self.importer = importer
+        self.imported = imported
+
+    def has_wildcard_expression(self) -> bool:
+        return "*" in self.imported or "*" in self.importer
+
+    def __str__(self) -> str:
+        return "{} -> {}".format(self.importer, self.imported)

--- a/tests/assets/testpackage/.setup.toml
+++ b/tests/assets/testpackage/.setup.toml
@@ -1,0 +1,11 @@
+[tool.importlinter]
+root_package = "testpackage"
+
+[[tool.importlinter.contracts]]
+name = "Test independence contract"
+type = "independence"
+modules = ["testpackage.high.blue", "testpackage.high.green"]
+ignore_imports = [
+    "testpackage.utils -> testpackage.high.green",
+    "testpackage.*.blue.* -> testpackage.indirect.*",
+]

--- a/tests/assets/testpackage/setup.cfg
+++ b/tests/assets/testpackage/setup.cfg
@@ -9,3 +9,4 @@ modules=
     testpackage.high.green
 ignore_imports=
     testpackage.utils -> testpackage.high.green
+    testpackage.*.blue.* -> testpackage.indirect.*

--- a/tests/assets/testpackage/testpackage/high/blue/one.py
+++ b/tests/assets/testpackage/testpackage/high/blue/one.py
@@ -1,1 +1,2 @@
 from testpackage import utils
+from testpackage.indirect import yellow

--- a/tests/assets/testpackage/testpackage/high/blue/two.py
+++ b/tests/assets/testpackage/testpackage/high/blue/two.py
@@ -1,0 +1,1 @@
+from testpackage.indirect import brown

--- a/tests/assets/testpackage/testpackage/indirect/brown.py
+++ b/tests/assets/testpackage/testpackage/indirect/brown.py
@@ -1,0 +1,1 @@
+import testpackage.high.green

--- a/tests/assets/testpackage/testpackage/indirect/yellow.py
+++ b/tests/assets/testpackage/testpackage/indirect/yellow.py
@@ -1,0 +1,1 @@
+import testpackage.high.green

--- a/tests/functional/test_lint_imports.py
+++ b/tests/functional/test_lint_imports.py
@@ -15,6 +15,34 @@ multipleroots_directory = os.path.join(os.path.dirname(__file__), "..", "assets"
         (testpackage_directory, ".brokencontract.ini", cli.EXIT_STATUS_ERROR),
         (testpackage_directory, ".malformedcontract.ini", cli.EXIT_STATUS_ERROR),
         (testpackage_directory, ".customkeptcontract.ini", cli.EXIT_STATUS_SUCCESS),
+        (testpackage_directory, ".externalbrokencontract.ini", cli.EXIT_STATUS_ERROR),
+        (multipleroots_directory, ".multiplerootskeptcontract.ini", cli.EXIT_STATUS_SUCCESS),
+        (multipleroots_directory, ".multiplerootsbrokencontract.ini", cli.EXIT_STATUS_ERROR),
+        # TOML versions.
+        pytest.param(
+            testpackage_directory,
+            ".setup.toml",
+            cli.EXIT_STATUS_ERROR,
+            marks=pytest.mark.toml_not_installed,
+        ),
+        pytest.param(
+            testpackage_directory,
+            ".setup.toml",
+            cli.EXIT_STATUS_SUCCESS,
+            marks=pytest.mark.toml_installed,
+        ),
+        pytest.param(
+            testpackage_directory,
+            ".customkeptcontract.toml",
+            cli.EXIT_STATUS_ERROR,
+            marks=pytest.mark.toml_not_installed,
+        ),
+        pytest.param(
+            testpackage_directory,
+            ".customkeptcontract.toml",
+            cli.EXIT_STATUS_SUCCESS,
+            marks=pytest.mark.toml_installed,
+        ),
         pytest.param(
             testpackage_directory,
             ".customkeptcontract.toml",
@@ -34,9 +62,6 @@ multipleroots_directory = os.path.join(os.path.dirname(__file__), "..", "assets"
             cli.EXIT_STATUS_SUCCESS,
             marks=pytest.mark.toml_installed,
         ),
-        (testpackage_directory, ".externalbrokencontract.ini", cli.EXIT_STATUS_ERROR),
-        (multipleroots_directory, ".multiplerootskeptcontract.ini", cli.EXIT_STATUS_SUCCESS),
-        (multipleroots_directory, ".multiplerootsbrokencontract.ini", cli.EXIT_STATUS_ERROR),
     ),
 )
 def test_lint_imports(working_directory, config_filename, expected_result):

--- a/tests/helpers/contracts.py
+++ b/tests/helpers/contracts.py
@@ -53,7 +53,7 @@ class ForbiddenImportContract(Contract):
 class FieldsContract(Contract):
     single_field = fields.StringField()
     multiple_field = fields.ListField(subfield=fields.StringField())
-    import_field = fields.DirectImportField()
+    import_field = fields.ImportExpressionField()
     required_field = fields.StringField()  # Fields are required by default.
 
     def check(self, graph: ImportGraph) -> ContractCheck:

--- a/tests/unit/contracts/test_independence.py
+++ b/tests/unit/contracts/test_independence.py
@@ -271,6 +271,10 @@ class TestIndependenceContract:
         (["mypackage.a -> mypackage.irrelevant"], False),
         (["mypackage.a -> mypackage.indirect"], True),
         (["mypackage.indirect -> mypackage.b"], True),
+        # Wildcards
+        (["mypackage.a -> *.irrelevant"], False),
+        (["*.a -> *.indirect"], True),
+        (["mypackage.* -> mypackage.b"], True),
     ),
 )
 def test_ignore_imports(ignore_imports, is_kept):

--- a/tests/unit/contracts/test_layers.py
+++ b/tests/unit/contracts/test_layers.py
@@ -673,10 +673,25 @@ class TestLayerContractPopulatesMetadata:
 
 
 class TestIgnoreImports:
-    def test_one_ignored_from_each_chain_means_contract_is_kept(self):
+    @pytest.mark.parametrize(
+        "expression",
+        [
+            "mypackage.low.black -> mypackage.medium.orange",
+            # Wildcards.
+            "*.low.black -> mypackage.medium.orange",
+            "mypackage.*.black -> mypackage.medium.orange",
+            "mypackage.low.* -> mypackage.medium.orange",
+            "mypackage.low.black -> *.medium.orange",
+            "mypackage.low.black -> mypackage.*.orange",
+            "mypackage.low.black -> mypackage.medium.*",
+            "mypackage.*.black -> mypackage.*.orange",
+            "mypackage.*.* -> mypackage.*.*",
+        ],
+    )
+    def test_one_ignored_from_each_chain_means_contract_is_kept(self, expression):
         contract = self._build_contract(
             ignore_imports=[
-                "mypackage.low.black -> mypackage.medium.orange",
+                expression,
                 "mypackage.utils.foo -> mypackage.utils.bar",
             ]
         )
@@ -747,19 +762,29 @@ class TestIgnoreImports:
             }
         ]
 
-    def test_ignore_from_nonexistent_importer_raises_missing_import(self):
-        contract = self._build_contract(
-            ignore_imports=["mypackage.nonexistent.foo -> mypackage.high"]
-        )
+    @pytest.mark.parametrize(
+        "expression",
+        [
+            "mypackage.nonexistent.foo -> mypackage.high",
+            "mypackage.nonexistent.* -> mypackage.high",
+        ],
+    )
+    def test_ignore_from_nonexistent_importer_raises_missing_import(self, expression):
+        contract = self._build_contract(ignore_imports=[expression])
         graph = self._build_graph()
 
         with pytest.raises(MissingImport):
             contract.check(graph=graph)
 
-    def test_ignore_from_nonexistent_imported_raises_missing_import(self):
-        contract = self._build_contract(
-            ignore_imports=["mypackage.high -> mypackage.nonexistent.foo"]
-        )
+    @pytest.mark.parametrize(
+        "expression",
+        [
+            "mypackage.high -> mypackage.nonexistent.foo",
+            "mypackage.high -> mypackage.nonexistent.*",
+        ],
+    )
+    def test_ignore_from_nonexistent_imported_raises_missing_import(self, expression):
+        contract = self._build_contract(ignore_imports=[expression])
         graph = self._build_graph()
 
         with pytest.raises(MissingImport):

--- a/tests/unit/domain/test_helpers.py
+++ b/tests/unit/domain/test_helpers.py
@@ -1,5 +1,293 @@
+import re
+from typing import Dict, List, Union, cast
+
+import pytest
 from grimp.adaptors.graph import ImportGraph  # type: ignore
-from importlinter.domain.helpers import add_imports
+
+from importlinter.domain.helpers import (
+    MissingImport,
+    add_imports,
+    import_expressions_to_imports,
+    pop_import_expressions,
+    pop_imports,
+)
+from importlinter.domain.imports import DirectImport, ImportExpression, Module
+
+
+class TestPopImports:
+    IMPORTS = [
+        dict(
+            importer="mypackage.green",
+            imported="mypackage.yellow",
+            line_number=1,
+            line_contents="blah",
+        ),
+        dict(
+            importer="mypackage.green",
+            imported="mypackage.blue",
+            line_number=2,
+            line_contents="blahblah",
+        ),
+        dict(
+            importer="mypackage.blue",
+            imported="mypackage.green",
+            line_number=10,
+            line_contents="blahblahblah",
+        ),
+    ]
+
+    def test_succeeds(self):
+        graph = self._build_graph(imports=self.IMPORTS)
+        imports_to_pop = self.IMPORTS[0:2]
+        import_to_leave = self.IMPORTS[2]
+
+        result = pop_imports(
+            graph,
+            [
+                DirectImport(importer=Module(i["importer"]), imported=Module(i["imported"]))
+                for i in imports_to_pop
+            ],
+        )
+
+        assert result == imports_to_pop
+        assert graph.direct_import_exists(
+            importer=import_to_leave["importer"], imported=import_to_leave["imported"]
+        )
+        assert graph.count_imports() == 1
+
+    def test_raises_missing_import_if_module_not_found(self):
+        graph = self._build_graph(imports=self.IMPORTS)
+        non_existent_import = DirectImport(
+            importer=Module("mypackage.nonexistent"),
+            imported=Module("mypackage.yellow"),
+            line_number=1,
+            line_contents="-",
+        )
+        with pytest.raises(
+            MissingImport,
+            match=re.escape(f"Ignored import {non_existent_import} not present in the graph."),
+        ):
+            pop_imports(graph, [non_existent_import])
+
+    def _build_graph(self, imports):
+        graph = ImportGraph()
+        for import_ in imports:
+            graph.add_import(**import_)
+        return graph
+
+
+class TestImportExpressionsToImports:
+    DIRECT_IMPORTS = [
+        DirectImport(
+            importer=Module("mypackage.green"),
+            imported=Module("mypackage.yellow"),
+            line_number=1,
+            line_contents="-",
+        ),
+        DirectImport(
+            importer=Module("mypackage.green"),
+            imported=Module("mypackage.blue"),
+            line_number=1,
+            line_contents="-",
+        ),
+        DirectImport(
+            importer=Module("mypackage.blue"),
+            imported=Module("mypackage.green"),
+            line_number=1,
+            line_contents="-",
+        ),
+        DirectImport(
+            importer=Module("mypackage.blue.cats"),
+            imported=Module("mypackage.purple.dogs"),
+            line_number=1,
+            line_contents="-",
+        ),
+        DirectImport(
+            importer=Module("mypackage.green.cats"),
+            imported=Module("mypackage.orange.dogs"),
+            line_number=1,
+            line_contents="-",
+        ),
+        DirectImport(
+            importer=Module("mypackage.green.cats"),
+            imported=Module("mypackage.orange.mice"),
+            line_number=1,
+            line_contents="-",
+        ),
+    ]
+
+    @pytest.mark.parametrize(
+        "description, expressions, expected",
+        [
+            (
+                "No wildcards",
+                [
+                    ImportExpression(
+                        importer=DIRECT_IMPORTS[0].importer.name,
+                        imported=DIRECT_IMPORTS[0].imported.name,
+                    ),
+                ],
+                [DIRECT_IMPORTS[0]],
+            ),
+            (
+                "Importer wildcard",
+                [
+                    ImportExpression(importer="mypackage.*", imported="mypackage.blue"),
+                ],
+                [DIRECT_IMPORTS[1]],
+            ),
+            (
+                "Imported wildcard",
+                [
+                    ImportExpression(importer="mypackage.green", imported="mypackage.*"),
+                ],
+                DIRECT_IMPORTS[0:2],
+            ),
+            (
+                "Importer and imported wildcards",
+                [
+                    ImportExpression(importer="mypackage.*", imported="mypackage.*"),
+                ],
+                DIRECT_IMPORTS[0:3],
+            ),
+            (
+                "Inner wildcard",
+                [
+                    ImportExpression(importer="mypackage.*.cats", imported="mypackage.*.dogs"),
+                ],
+                DIRECT_IMPORTS[3:5],
+            ),
+            (
+                "Multiple expressions, non-overlapping",
+                [
+                    ImportExpression(importer="mypackage.green", imported="mypackage.*"),
+                    ImportExpression(
+                        importer="mypackage.green.cats", imported="mypackage.orange.*"
+                    ),
+                ],
+                DIRECT_IMPORTS[0:2] + DIRECT_IMPORTS[4:6],
+            ),
+            (
+                "Multiple expressions, overlapping",
+                [
+                    ImportExpression(importer="mypackage.*", imported="mypackage.blue"),
+                    ImportExpression(importer="mypackage.green", imported="mypackage.blue"),
+                ],
+                [DIRECT_IMPORTS[1]],
+            ),
+        ],
+    )
+    def test_succeeds(self, description, expressions, expected):
+        graph = self._build_graph(self.DIRECT_IMPORTS)
+
+        assert sorted(
+            import_expressions_to_imports(graph, expressions), key=_direct_import_sort_key
+        ) == sorted(expected, key=_direct_import_sort_key)
+
+    def test_raises_missing_import(self):
+        graph = ImportGraph()
+        graph.add_module("mypackage")
+        graph.add_module("other")
+        graph.add_import(
+            importer="mypackage.b", imported="other.foo", line_number=1, line_contents="-"
+        )
+
+        expression = ImportExpression(importer="mypackage.a.*", imported="other.foo")
+        with pytest.raises(MissingImport):
+            import_expressions_to_imports(graph, [expression])
+
+    def _build_graph(self, direct_imports):
+        graph = ImportGraph()
+        for direct_import in direct_imports:
+            graph.add_import(
+                importer=direct_import.importer.name,
+                imported=direct_import.imported.name,
+                line_number=direct_import.line_number,
+                line_contents=direct_import.line_contents,
+            )
+        return graph
+
+
+class TestPopImportExpressions:
+    DIRECT_IMPORTS = [
+        DirectImport(
+            importer=Module("mypackage.green"),
+            imported=Module("mypackage.yellow"),
+            line_number=1,
+            line_contents="-",
+        ),
+        DirectImport(
+            importer=Module("mypackage.green"),
+            imported=Module("mypackage.blue"),
+            line_number=1,
+            line_contents="-",
+        ),
+        DirectImport(
+            importer=Module("mypackage.blue"),
+            imported=Module("mypackage.green"),
+            line_number=1,
+            line_contents="-",
+        ),
+        DirectImport(
+            importer=Module("mypackage.blue.cats"),
+            imported=Module("mypackage.purple.dogs"),
+            line_number=1,
+            line_contents="-",
+        ),
+        DirectImport(
+            importer=Module("mypackage.green.cats"),
+            imported=Module("mypackage.orange.dogs"),
+            line_number=1,
+            line_contents="-",
+        ),
+    ]
+
+    def test_succeeds(self):
+        graph = self._build_graph(self.DIRECT_IMPORTS)
+        expressions = [
+            ImportExpression(importer="mypackage.green", imported="mypackage.*"),
+            # Expressions can overlap.
+            ImportExpression(importer="mypackage.green", imported="mypackage.blue"),
+            ImportExpression(importer="mypackage.blue.cats", imported="mypackage.purple.dogs"),
+        ]
+
+        popped_imports: List[Dict[str, Union[str, int]]] = pop_import_expressions(
+            graph, expressions
+        )
+
+        # Cast to direct imports to make comparison easier.
+        popped_direct_imports: List[DirectImport] = sorted(
+            map(self._dict_to_direct_import, popped_imports), key=_direct_import_sort_key
+        )
+        expected = sorted(
+            [
+                self.DIRECT_IMPORTS[0],
+                self.DIRECT_IMPORTS[1],
+                self.DIRECT_IMPORTS[3],
+            ],
+            key=_direct_import_sort_key,
+        )
+        assert popped_direct_imports == expected
+        assert graph.count_imports() == 2
+
+    def _build_graph(self, direct_imports):
+        graph = ImportGraph()
+        for direct_import in direct_imports:
+            graph.add_import(
+                importer=direct_import.importer.name,
+                imported=direct_import.imported.name,
+                line_number=direct_import.line_number,
+                line_contents=direct_import.line_contents,
+            )
+        return graph
+
+    def _dict_to_direct_import(self, import_details: Dict[str, Union[str, int]]) -> DirectImport:
+        return DirectImport(
+            importer=Module(cast(str, import_details["importer"])),
+            imported=Module(cast(str, import_details["imported"])),
+            line_number=cast(int, import_details["line_number"]),
+            line_contents=cast(str, import_details["line_contents"]),
+        )
 
 
 def test_add_imports():
@@ -11,3 +299,12 @@ def test_add_imports():
     assert not graph.modules
     add_imports(graph, import_details)
     assert graph.modules == {"a", "b", "c", "d"}
+
+
+def _direct_import_sort_key(direct_import: DirectImport):
+    # Doesn't matter how we sort, just a way of sorting consistently for comparison.
+    return (
+        direct_import.importer.name,
+        direct_import.imported.name,
+        direct_import.line_number,
+    )


### PR DESCRIPTION
This supports the use of wildcards in the `ignore_imports` of contracts.