### PR TITLE
Ignore missing expressions

### DIFF
--- a/src/importlinter/application/output.py
+++ b/src/importlinter/application/output.py
@@ -5,7 +5,8 @@ from .ports.printing import Printer
 
 ERROR = "error"
 SUCCESS = "success"
-COLORS = {ERROR: "red", SUCCESS: "green"}
+WARNING = "warning"
+COLORS = {ERROR: "red", SUCCESS: "green", WARNING: "yellow"}
 
 HEADING_LEVEL_ONE = 1
 HEADING_LEVEL_TWO = 2
@@ -95,6 +96,12 @@ class Output:
         """
         self.printer.print(text, color=COLORS[ERROR], bold=bold)
 
+    def print_warning(self, text):
+        """
+        Prints a line to the console, formatted as a warning.
+        """
+        self.printer.print(text, color=COLORS[WARNING])
+
     @property
     def printer(self) -> Printer:
         return settings.PRINTER
@@ -109,3 +116,4 @@ new_line = _instance.new_line
 print_success = _instance.print_success
 print_heading = _instance.print_heading
 print_error = _instance.print_error
+print_warning = _instance.print_warning

--- a/src/importlinter/contracts/forbidden.py
+++ b/src/importlinter/contracts/forbidden.py
@@ -1,8 +1,10 @@
-from typing import Tuple, cast
+from typing import Sequence, Tuple, cast
 
 from importlinter.application import output
 from importlinter.domain import fields, helpers
 from importlinter.domain.contract import Contract, ContractCheck
+from importlinter.domain.imports import ImportExpression
+from importlinter.domain.output import AlertLevel
 from importlinter.domain.ports.graph import ImportGraph
 
 
@@ -30,19 +32,21 @@ class ForbiddenContract(Contract):
     ignore_imports = fields.SetField(subfield=fields.ImportExpressionField(), required=False)
     allow_indirect_imports = fields.StringField(required=False)
     unmatched_ignore_imports_alerting = fields.EnumField(
-        helpers.AlertLevel, default=helpers.AlertLevel.ERROR, required=False
+        AlertLevel, default=AlertLevel.ERROR, required=False
     )
 
     def check(self, graph: ImportGraph) -> ContractCheck:
         is_kept = True
         invalid_chains = []
 
-        helpers.pop_import_expressions(
-            graph,
-            self.ignore_imports if self.ignore_imports else [],  # type: ignore
-            if_not_matched=self.unmatched_ignore_imports_alerting,  # type: ignore
+        _, unresolved = helpers.pop_unresolved_import_expressions(
+            graph, self.ignore_imports if self.ignore_imports else []  # type: ignore
         )
 
+        self._check_unresolved_imports(
+            unresolved,
+            self.unmatched_ignore_imports_alerting,  # type: ignore
+        )
         self._check_all_modules_exist_in_graph(graph)
         self._check_external_forbidden_modules(graph)
 
@@ -143,3 +147,31 @@ class ForbiddenContract(Contract):
 
     def _graph_was_built_with_externals(self) -> bool:
         return str(self.session_options.get("include_external_packages")).lower() == "true"
+
+    def _check_unresolved_imports(
+        self, unresolved_imports: Sequence[ImportExpression], alert_level: AlertLevel
+    ) -> None:
+        if len(unresolved_imports) == 0 or alert_level == AlertLevel.NONE:
+            # Skip if no unresolved imports or no alerting
+            return
+
+        elif alert_level == AlertLevel.WARN:
+            # Print warnings for each unresolved import
+            for unresolved_import in unresolved_imports:
+                output.print_warning(
+                    f"Ignored import expression {unresolved_import} "
+                    "didn't match anything in the graph."
+                )
+            return
+
+        else:
+            # Raise exception for first unresolved import
+            unresolved_imports_str = (
+                str(unresolved_import) for unresolved_import in unresolved_imports
+            )
+            unresolved_import_str = sorted(unresolved_imports_str)[0]
+
+            raise ValueError(
+                f"Ignored import expression {unresolved_import_str} "
+                "didn't match anything in the graph."
+            )

--- a/src/importlinter/contracts/forbidden.py
+++ b/src/importlinter/contracts/forbidden.py
@@ -17,7 +17,7 @@ class ForbiddenContract(Contract):
                              would cause a contract to be broken, adding it to the set will cause
                              the contract be kept instead. (Optional.)
         - allow_indirect_imports:  Whether to allow indirect imports to forbidden modules.
-                            "True" or "true" will be treated as True. (Optional.)```
+                            "True" or "true" will be treated as True. (Optional.)
     """
 
     type_name = "forbidden"

--- a/src/importlinter/contracts/forbidden.py
+++ b/src/importlinter/contracts/forbidden.py
@@ -29,19 +29,18 @@ class ForbiddenContract(Contract):
     forbidden_modules = fields.ListField(subfield=fields.ModuleField())
     ignore_imports = fields.SetField(subfield=fields.ImportExpressionField(), required=False)
     allow_indirect_imports = fields.StringField(required=False)
-    unmatched_ignore_imports_alerting = fields.StringField(required=False)
+    unmatched_ignore_imports_alerting = fields.EnumField(
+        helpers.AlertLevel, default=helpers.AlertLevel.ERROR, required=False
+    )
 
     def check(self, graph: ImportGraph) -> ContractCheck:
         is_kept = True
         invalid_chains = []
-        alerting_level = helpers.parse_unmatched_ignore_imports_alerting(
-            self.unmatched_ignore_imports_alerting
-        )
 
         helpers.pop_import_expressions(
             graph,
             self.ignore_imports if self.ignore_imports else [],  # type: ignore
-            if_not_matched=alerting_level,
+            if_not_matched=self.unmatched_ignore_imports_alerting,  # type: ignore
         )
 
         self._check_all_modules_exist_in_graph(graph)

--- a/src/importlinter/contracts/independence.py
+++ b/src/importlinter/contracts/independence.py
@@ -19,19 +19,28 @@ class IndependenceContract(Contract):
         - ignore_imports: A set of ImportExpressions. These imports will be ignored: if the import
                           would cause a contract to be broken, adding it to the set will cause
                           the contract be kept instead. (Optional.)
+        - unmatched_ignore_imports_alerting: Decides how to report when the expression in the
+                          `ignore_imports` set is not found in the graph. Valid values are
+                          "none", "warn", "error". Default value is "error".
     """
 
     type_name = "independence"
 
     modules = fields.ListField(subfield=fields.ModuleField())
     ignore_imports = fields.SetField(subfield=fields.ImportExpressionField(), required=False)
+    unmatched_ignore_imports_alerting = fields.StringField(required=False)
 
     def check(self, graph: ImportGraph) -> ContractCheck:
         is_kept = True
         invalid_chains = []
+        alerting_level = helpers.parse_unmatched_ignore_imports_alerting(
+            self.unmatched_ignore_imports_alerting
+        )
 
         helpers.pop_import_expressions(
-            graph, self.ignore_imports if self.ignore_imports else []  # type: ignore
+            graph,
+            self.ignore_imports if self.ignore_imports else [],  # type: ignore
+            if_not_matched=alerting_level,
         )
 
         self._check_all_modules_exist_in_graph(graph)

--- a/src/importlinter/contracts/independence.py
+++ b/src/importlinter/contracts/independence.py
@@ -1,8 +1,11 @@
 from itertools import permutations
+from typing import Sequence
 
 from importlinter.application import output
 from importlinter.domain import fields, helpers
 from importlinter.domain.contract import Contract, ContractCheck
+from importlinter.domain.imports import ImportExpression
+from importlinter.domain.output import AlertLevel
 from importlinter.domain.ports.graph import ImportGraph
 
 
@@ -29,19 +32,21 @@ class IndependenceContract(Contract):
     modules = fields.ListField(subfield=fields.ModuleField())
     ignore_imports = fields.SetField(subfield=fields.ImportExpressionField(), required=False)
     unmatched_ignore_imports_alerting = fields.EnumField(
-        helpers.AlertLevel, default=helpers.AlertLevel.ERROR, required=False
+        AlertLevel, default=AlertLevel.ERROR, required=False
     )
 
     def check(self, graph: ImportGraph) -> ContractCheck:
         is_kept = True
         invalid_chains = []
 
-        helpers.pop_import_expressions(
-            graph,
-            self.ignore_imports if self.ignore_imports else [],  # type: ignore
-            if_not_matched=self.unmatched_ignore_imports_alerting,  # type: ignore
+        _, unresolved = helpers.pop_unresolved_import_expressions(
+            graph, self.ignore_imports if self.ignore_imports else []  # type: ignore
         )
 
+        self._check_unresolved_imports(
+            unresolved,
+            self.unmatched_ignore_imports_alerting,  # type: ignore
+        )
         self._check_all_modules_exist_in_graph(graph)
 
         for subpackage_1, subpackage_2 in permutations(self.modules, r=2):  # type: ignore
@@ -108,3 +113,31 @@ class IndependenceContract(Contract):
         for module in self.modules:  # type: ignore
             if module.name not in graph.modules:
                 raise ValueError(f"Module '{module.name}' does not exist.")
+
+    def _check_unresolved_imports(
+        self, unresolved_imports: Sequence[ImportExpression], alert_level: AlertLevel
+    ) -> None:
+        if len(unresolved_imports) == 0 or alert_level == AlertLevel.NONE:
+            # Skip if no unresolved imports or no alerting
+            return
+
+        elif alert_level == AlertLevel.WARN:
+            # Print warnings for each unresolved import
+            for unresolved_import in unresolved_imports:
+                output.print_warning(
+                    f"Ignored import expression {unresolved_import} "
+                    "didn't match anything in the graph."
+                )
+            return
+
+        else:
+            # Raise exception for first unresolved import
+            unresolved_imports_str = (
+                str(unresolved_import) for unresolved_import in unresolved_imports
+            )
+            unresolved_import_str = sorted(unresolved_imports_str)[0]
+
+            raise ValueError(
+                f"Ignored import expression {unresolved_import_str} "
+                "didn't match anything in the graph."
+            )

--- a/src/importlinter/contracts/independence.py
+++ b/src/importlinter/contracts/independence.py
@@ -28,19 +28,18 @@ class IndependenceContract(Contract):
 
     modules = fields.ListField(subfield=fields.ModuleField())
     ignore_imports = fields.SetField(subfield=fields.ImportExpressionField(), required=False)
-    unmatched_ignore_imports_alerting = fields.StringField(required=False)
+    unmatched_ignore_imports_alerting = fields.EnumField(
+        helpers.AlertLevel, default=helpers.AlertLevel.ERROR, required=False
+    )
 
     def check(self, graph: ImportGraph) -> ContractCheck:
         is_kept = True
         invalid_chains = []
-        alerting_level = helpers.parse_unmatched_ignore_imports_alerting(
-            self.unmatched_ignore_imports_alerting
-        )
 
         helpers.pop_import_expressions(
             graph,
             self.ignore_imports if self.ignore_imports else [],  # type: ignore
-            if_not_matched=alerting_level,
+            if_not_matched=self.unmatched_ignore_imports_alerting,  # type: ignore
         )
 
         self._check_all_modules_exist_in_graph(graph)

--- a/src/importlinter/contracts/layers.py
+++ b/src/importlinter/contracts/layers.py
@@ -55,18 +55,19 @@ class LayersContract(Contract):
     layers = fields.ListField(subfield=LayerField())
     containers = fields.ListField(subfield=fields.StringField(), required=False)
     ignore_imports = fields.SetField(subfield=fields.ImportExpressionField(), required=False)
-    unmatched_ignore_imports_alerting = fields.StringField(required=False)
+    unmatched_ignore_imports_alerting = fields.EnumField(
+        helpers.AlertLevel, default=helpers.AlertLevel.ERROR, required=False
+    )
 
     def check(self, graph: ImportGraph) -> ContractCheck:
         is_kept = True
         invalid_chains = []
         direct_imports_to_ignore = self.ignore_imports if self.ignore_imports else []
-        alerting_level = helpers.parse_unmatched_ignore_imports_alerting(
-            self.unmatched_ignore_imports_alerting
-        )
 
         helpers.pop_import_expressions(
-            graph, direct_imports_to_ignore, if_not_matched=alerting_level  # type: ignore
+            graph,
+            direct_imports_to_ignore,  # type: ignore
+            if_not_matched=self.unmatched_ignore_imports_alerting,  # type: ignore
         )
 
         if self.containers:

--- a/src/importlinter/domain/fields.py
+++ b/src/importlinter/domain/fields.py
@@ -1,5 +1,6 @@
 import abc
-from typing import Generic, Iterable, List, Set, TypeVar, Union
+from enum import Enum
+from typing import Generic, Iterable, List, Set, Type, TypeVar, Union
 
 from importlinter.domain.imports import Module, ImportExpression
 
@@ -136,3 +137,27 @@ class ImportExpressionField(Field):
         for part in expression.split("."):
             if len(part) > 1 and "*" in part:
                 raise ValidationError("A wildcard can only replace a whole module.")
+
+
+class EnumField(Field):
+    """ """
+
+    def __init__(self, enum: Type[Enum], default: Enum, required: bool = True) -> None:
+        super().__init__(required)
+
+        self._enum = enum
+        self._default = default
+
+    def parse(self, raw_data: Union[str, List[str]]) -> Enum:
+        string = StringField().parse(raw_data).strip()
+
+        if string == "":
+            return self._default
+
+        try:
+            return self._enum[string.upper()]
+        except KeyError:
+            raise ValidationError(
+                f"Invalid value `{string}` "
+                f"must be one of {[member.value for member in self._enum]}"
+            )

--- a/src/importlinter/domain/helpers.py
+++ b/src/importlinter/domain/helpers.py
@@ -9,7 +9,7 @@ from importlinter.domain.ports.graph import ImportGraph
 
 
 @enum.unique
-class AlertingLevels(enum.Enum):
+class AlertLevel(enum.Enum):
     NONE = "none"
     WARN = "warn"
     ERROR = "error"
@@ -52,7 +52,7 @@ def pop_imports(
 
 
 def import_expressions_to_imports(
-    graph: ImportGraph, expressions: Iterable[ImportExpression], if_not_matched: AlertingLevels
+    graph: ImportGraph, expressions: Iterable[ImportExpression], if_not_matched: AlertLevel
 ) -> List[DirectImport]:
     """
     Returns a list of imports in a graph, given some import expressions.
@@ -80,12 +80,12 @@ def import_expressions_to_imports(
                     )
                 matched = True
         if not matched:
-            if if_not_matched == AlertingLevels.NONE:
+            if if_not_matched == AlertLevel.NONE:
                 return []
 
             message = f"Ignored import expression {expression} didn't match anything in the graph."
 
-            if if_not_matched == AlertingLevels.WARN:
+            if if_not_matched == AlertLevel.WARN:
                 output.print_warning(message)
                 return []
             else:
@@ -97,7 +97,7 @@ def import_expressions_to_imports(
 def pop_import_expressions(
     graph: ImportGraph,
     expressions: Iterable[ImportExpression],
-    if_not_matched: AlertingLevels = AlertingLevels.ERROR,
+    if_not_matched: AlertLevel = AlertLevel.ERROR,
 ) -> List[Dict[str, Union[str, int]]]:
     """
     Removes any imports matching the supplied import expressions from the graph.
@@ -212,19 +212,19 @@ def _expression_to_modules(
     return itertools.product(set(importer), set(imported))
 
 
-def parse_unmatched_ignore_imports_alerting(value: Any) -> AlertingLevels:
+def parse_unmatched_ignore_imports_alerting(value: Any) -> AlertLevel:
     if value is None:
-        return AlertingLevels.ERROR
+        return AlertLevel.ERROR
 
     value_str = str(value).strip()
 
     if value_str == "":
-        return AlertingLevels.ERROR
+        return AlertLevel.ERROR
 
     try:
-        return AlertingLevels[value_str.upper()]
+        return AlertLevel[value_str.upper()]
     except KeyError:
         raise ValueError(
             f"Invalid value `{value}` for unmatched_ignore_imports_alerting; "
-            f"must be one of {[member.value for member in AlertingLevels]}"
+            f"must be one of {[member.value for member in AlertLevel]}"
         )

--- a/src/importlinter/domain/helpers.py
+++ b/src/importlinter/domain/helpers.py
@@ -1,7 +1,7 @@
 import enum
 import itertools
 import re
-from typing import Any, Dict, Iterable, List, Pattern, Set, Tuple, Union, cast
+from typing import Dict, Iterable, List, Pattern, Set, Tuple, Union, cast
 from importlinter.application import output
 
 from importlinter.domain.imports import DirectImport, ImportExpression, Module
@@ -210,21 +210,3 @@ def _expression_to_modules(
             imported.append(Module(module))
 
     return itertools.product(set(importer), set(imported))
-
-
-def parse_unmatched_ignore_imports_alerting(value: Any) -> AlertLevel:
-    if value is None:
-        return AlertLevel.ERROR
-
-    value_str = str(value).strip()
-
-    if value_str == "":
-        return AlertLevel.ERROR
-
-    try:
-        return AlertLevel[value_str.upper()]
-    except KeyError:
-        raise ValueError(
-            f"Invalid value `{value}` for unmatched_ignore_imports_alerting; "
-            f"must be one of {[member.value for member in AlertLevel]}"
-        )

--- a/src/importlinter/domain/output.py
+++ b/src/importlinter/domain/output.py
@@ -1,0 +1,8 @@
+import enum
+
+
+@enum.unique
+class AlertLevel(enum.Enum):
+    NONE = "none"
+    WARN = "warn"
+    ERROR = "error"

--- a/tests/unit/contracts/test_layers.py
+++ b/tests/unit/contracts/test_layers.py
@@ -769,11 +769,12 @@ class TestIgnoreImports:
             "mypackage.nonexistent.* -> mypackage.high",
         ],
     )
-    def test_ignore_from_nonexistent_importer_raises_missing_import(self, expression):
+    def test_ignore_from_nonexistent_importer_raises_value(self, expression):
         contract = self._build_contract(ignore_imports=[expression])
         graph = self._build_graph()
+        message = f"Ignored import expression {expression} didn't match anything in the graph."
 
-        with pytest.raises(MissingImport):
+        with pytest.raises(ValueError, match=message):
             contract.check(graph=graph)
 
     @pytest.mark.parametrize(
@@ -783,11 +784,12 @@ class TestIgnoreImports:
             "mypackage.high -> mypackage.nonexistent.*",
         ],
     )
-    def test_ignore_from_nonexistent_imported_raises_missing_import(self, expression):
+    def test_ignore_from_nonexistent_imported_raises_value(self, expression):
         contract = self._build_contract(ignore_imports=[expression])
         graph = self._build_graph()
+        message = f"Ignored import expression {expression} didn't match anything in the graph."
 
-        with pytest.raises(MissingImport):
+        with pytest.raises(ValueError, match=message):
             contract.check(graph=graph)
 
     def test_ignore_imports_tolerates_duplicates(self):

--- a/tests/unit/domain/test_helpers.py
+++ b/tests/unit/domain/test_helpers.py
@@ -5,7 +5,7 @@ import pytest
 from grimp.adaptors.graph import ImportGraph  # type: ignore
 
 from importlinter.domain.helpers import (
-    AlertingLevels,
+    AlertLevel,
     MissingImport,
     add_imports,
     import_expressions_to_imports,
@@ -245,7 +245,7 @@ class TestImportExpressionsToImports:
     def test_succeeds(self, description, expressions, expected):
         graph = self._build_graph(self.DIRECT_IMPORTS)
         actual = sorted(
-            import_expressions_to_imports(graph, expressions, AlertingLevels.ERROR),
+            import_expressions_to_imports(graph, expressions, AlertLevel.ERROR),
             key=_direct_import_sort_key,
         )
         expected = sorted(expected, key=_direct_import_sort_key)
@@ -263,7 +263,7 @@ class TestImportExpressionsToImports:
         expression = ImportExpression(importer="mypackage.a.*", imported="other.foo")
 
         with pytest.raises(MissingImport):
-            import_expressions_to_imports(graph, [expression], AlertingLevels.ERROR)
+            import_expressions_to_imports(graph, [expression], AlertLevel.ERROR)
 
     def _build_graph(self, direct_imports):
         graph = ImportGraph()
@@ -383,16 +383,16 @@ def _direct_import_sort_key(direct_import: DirectImport):
     "value, expected",
     [
         # values
-        pytest.param("", AlertingLevels.ERROR),
-        pytest.param("error", AlertingLevels.ERROR),
-        pytest.param("warn", AlertingLevels.WARN),
-        pytest.param("none", AlertingLevels.NONE),
+        pytest.param("", AlertLevel.ERROR),
+        pytest.param("error", AlertLevel.ERROR),
+        pytest.param("warn", AlertLevel.WARN),
+        pytest.param("none", AlertLevel.NONE),
         # trailing/leading spaces
-        pytest.param(" ", AlertingLevels.ERROR),
-        pytest.param(" none  ", AlertingLevels.NONE),
+        pytest.param(" ", AlertLevel.ERROR),
+        pytest.param(" none  ", AlertLevel.NONE),
     ],
 )
-def test_parse_unmatched_ignore_imports_alerting(value: str, expected: AlertingLevels) -> None:
+def test_parse_unmatched_ignore_imports_alerting(value: str, expected: AlertLevel) -> None:
     actual = parse_unmatched_ignore_imports_alerting(value)
 
     assert actual == expected

--- a/tests/unit/domain/test_helpers.py
+++ b/tests/unit/domain/test_helpers.py
@@ -9,7 +9,6 @@ from importlinter.domain.helpers import (
     MissingImport,
     add_imports,
     import_expressions_to_imports,
-    parse_unmatched_ignore_imports_alerting,
     pop_import_expressions,
     pop_imports,
 )
@@ -377,30 +376,3 @@ def _direct_import_sort_key(direct_import: DirectImport):
         direct_import.imported.name,
         direct_import.line_number,
     )
-
-
-@pytest.mark.parametrize(
-    "value, expected",
-    [
-        # values
-        ("", AlertLevel.ERROR),
-        ("error", AlertLevel.ERROR),
-        ("warn", AlertLevel.WARN),
-        ("none", AlertLevel.NONE),
-        # trailing/leading spaces
-        (" ", AlertLevel.ERROR),
-        (" none  ", AlertLevel.NONE),
-    ],
-)
-def test_parse_unmatched_ignore_imports_alerting(value: str, expected: AlertLevel) -> None:
-    actual = parse_unmatched_ignore_imports_alerting(value)
-
-    assert actual == expected
-
-
-def test_parse_unmatched_ignore_imports_alerting_raise_if_not_valid() -> None:
-    value = "invalid"
-    message = f"Invalid value `{value}` for unmatched_ignore_imports_alerting"
-
-    with pytest.raises(ValueError, match=message):
-        parse_unmatched_ignore_imports_alerting(value)

--- a/tests/unit/domain/test_helpers.py
+++ b/tests/unit/domain/test_helpers.py
@@ -383,13 +383,13 @@ def _direct_import_sort_key(direct_import: DirectImport):
     "value, expected",
     [
         # values
-        pytest.param("", AlertLevel.ERROR),
-        pytest.param("error", AlertLevel.ERROR),
-        pytest.param("warn", AlertLevel.WARN),
-        pytest.param("none", AlertLevel.NONE),
+        ("", AlertLevel.ERROR),
+        ("error", AlertLevel.ERROR),
+        ("warn", AlertLevel.WARN),
+        ("none", AlertLevel.NONE),
         # trailing/leading spaces
-        pytest.param(" ", AlertLevel.ERROR),
-        pytest.param(" none  ", AlertLevel.NONE),
+        (" ", AlertLevel.ERROR),
+        (" none  ", AlertLevel.NONE),
     ],
 )
 def test_parse_unmatched_ignore_imports_alerting(value: str, expected: AlertLevel) -> None:

--- a/tests/unit/domain/test_helpers.py
+++ b/tests/unit/domain/test_helpers.py
@@ -5,12 +5,13 @@ import pytest
 from grimp.adaptors.graph import ImportGraph  # type: ignore
 
 from importlinter.domain.helpers import (
-    AlertLevel,
     MissingImport,
     add_imports,
     import_expressions_to_imports,
     pop_import_expressions,
     pop_imports,
+    pop_unresolved_import_expressions,
+    unresolved_import_expressions_to_imports,
 )
 from importlinter.domain.imports import DirectImport, ImportExpression, Module
 
@@ -243,13 +244,10 @@ class TestImportExpressionsToImports:
     )
     def test_succeeds(self, description, expressions, expected):
         graph = self._build_graph(self.DIRECT_IMPORTS)
-        actual = sorted(
-            import_expressions_to_imports(graph, expressions, AlertLevel.ERROR),
-            key=_direct_import_sort_key,
-        )
-        expected = sorted(expected, key=_direct_import_sort_key)
 
-        assert actual == expected
+        assert sorted(
+            import_expressions_to_imports(graph, expressions), key=_direct_import_sort_key
+        ) == sorted(expected, key=_direct_import_sort_key)
 
     def test_raises_missing_import(self):
         graph = ImportGraph()
@@ -260,10 +258,172 @@ class TestImportExpressionsToImports:
         )
 
         expression = ImportExpression(importer="mypackage.a.*", imported="other.foo")
-
         with pytest.raises(MissingImport):
-            import_expressions_to_imports(graph, [expression], AlertLevel.ERROR)
+            import_expressions_to_imports(graph, [expression])
 
+    def _build_graph(self, direct_imports):
+        graph = ImportGraph()
+        for direct_import in direct_imports:
+            graph.add_import(
+                importer=direct_import.importer.name,
+                imported=direct_import.imported.name,
+                line_number=direct_import.line_number,
+                line_contents=direct_import.line_contents,
+            )
+        return graph
+
+
+class TestUnresolvedImportExpressionsToImports:
+    DIRECT_IMPORTS = [
+        DirectImport(
+            importer=Module("mypackage.green"),
+            imported=Module("mypackage.yellow"),
+            line_number=1,
+            line_contents="-",
+        ),
+        DirectImport(
+            importer=Module("mypackage.green"),
+            imported=Module("mypackage.blue"),
+            line_number=1,
+            line_contents="-",
+        ),
+        DirectImport(
+            importer=Module("mypackage.blue"),
+            imported=Module("mypackage.green"),
+            line_number=1,
+            line_contents="-",
+        ),
+        DirectImport(
+            importer=Module("mypackage.blue.cats"),
+            imported=Module("mypackage.purple.dogs"),
+            line_number=1,
+            line_contents="-",
+        ),
+        DirectImport(
+            importer=Module("mypackage.green.cats"),
+            imported=Module("mypackage.orange.dogs"),
+            line_number=1,
+            line_contents="-",
+        ),
+        DirectImport(
+            importer=Module("mypackage.green.cats"),
+            imported=Module("mypackage.orange.mice"),
+            line_number=1,
+            line_contents="-",
+        ),
+        # Direct imports of external packages can appear more than once, as the external package
+        # is squashed.
+        DirectImport(
+            importer=Module("mypackage.brown"),
+            imported=Module("someotherpackage"),
+            line_number=1,
+            line_contents="from someotherpackage import one",
+        ),
+        DirectImport(
+            importer=Module("mypackage.brown"),
+            imported=Module("someotherpackage"),
+            line_number=2,
+            line_contents="from someotherpackage import two",
+        ),
+    ]
+
+    @pytest.mark.parametrize(
+        "description, expressions, expected",
+        [
+            (
+                "No wildcards",
+                [
+                    ImportExpression(
+                        importer=DIRECT_IMPORTS[0].importer.name,
+                        imported=DIRECT_IMPORTS[0].imported.name,
+                    ),
+                ],
+                [DIRECT_IMPORTS[0]],
+            ),
+            (
+                "Importer wildcard",
+                [
+                    ImportExpression(importer="mypackage.*", imported="mypackage.blue"),
+                ],
+                [DIRECT_IMPORTS[1]],
+            ),
+            (
+                "Imported wildcard",
+                [
+                    ImportExpression(importer="mypackage.green", imported="mypackage.*"),
+                ],
+                DIRECT_IMPORTS[0:2],
+            ),
+            (
+                "Importer and imported wildcards",
+                [
+                    ImportExpression(importer="mypackage.*", imported="mypackage.*"),
+                ],
+                DIRECT_IMPORTS[0:3],
+            ),
+            (
+                "Inner wildcard",
+                [
+                    ImportExpression(importer="mypackage.*.cats", imported="mypackage.*.dogs"),
+                ],
+                DIRECT_IMPORTS[3:5],
+            ),
+            (
+                "Multiple expressions, non-overlapping",
+                [
+                    ImportExpression(importer="mypackage.green", imported="mypackage.*"),
+                    ImportExpression(
+                        importer="mypackage.green.cats", imported="mypackage.orange.*"
+                    ),
+                ],
+                DIRECT_IMPORTS[0:2] + DIRECT_IMPORTS[4:6],
+            ),
+            (
+                "Multiple expressions, overlapping",
+                [
+                    ImportExpression(importer="mypackage.*", imported="mypackage.blue"),
+                    ImportExpression(importer="mypackage.green", imported="mypackage.blue"),
+                ],
+                [DIRECT_IMPORTS[1]],
+            ),
+            (
+                "Multiple imports of external package with same importer",
+                [
+                    ImportExpression(importer="mypackage.brown", imported="someotherpackage"),
+                ],
+                DIRECT_IMPORTS[6:8],
+            ),
+        ],
+    )
+    def test_succeeds(
+        self, description: str, expressions: List[ImportExpression], expected: List[DirectImport]
+    ):
+        graph = self._build_graph(self.DIRECT_IMPORTS)
+
+        actual = unresolved_import_expressions_to_imports(graph, expressions)
+        actual_resolved_imports, acautl_unresolved_imports = actual
+
+        assert acautl_unresolved_imports == []
+        assert sorted(actual_resolved_imports, key=_direct_import_sort_key) == sorted(
+            expected, key=_direct_import_sort_key
+        )
+
+    def test_returns_missing_import(self):
+        graph = ImportGraph()
+        graph.add_module("mypackage")
+        graph.add_module("other")
+        graph.add_import(
+            importer="mypackage.b", imported="other.foo", line_number=1, line_contents="-"
+        )
+
+        expression = ImportExpression(importer="mypackage.a.*", imported="other.foo")
+
+        actual = unresolved_import_expressions_to_imports(graph, [expression])
+        expected = ([], [ImportExpression(imported="other.foo", importer="mypackage.a.*")])
+
+        assert actual == expected
+
+    # fixme: make a base class
     def _build_graph(self, direct_imports):
         graph = ImportGraph()
         for direct_import in direct_imports:
@@ -336,6 +496,97 @@ class TestPopImportExpressions:
             key=_direct_import_sort_key,
         )
         assert popped_direct_imports == expected
+        assert graph.count_imports() == 2
+
+    def _build_graph(self, direct_imports):
+        graph = ImportGraph()
+        for direct_import in direct_imports:
+            graph.add_import(
+                importer=direct_import.importer.name,
+                imported=direct_import.imported.name,
+                line_number=direct_import.line_number,
+                line_contents=direct_import.line_contents,
+            )
+        return graph
+
+    def _dict_to_direct_import(self, import_details: Dict[str, Union[str, int]]) -> DirectImport:
+        return DirectImport(
+            importer=Module(cast(str, import_details["importer"])),
+            imported=Module(cast(str, import_details["imported"])),
+            line_number=cast(int, import_details["line_number"]),
+            line_contents=cast(str, import_details["line_contents"]),
+        )
+
+
+class TestPopUnresolvedImportExpressions:
+    # fixme: make shared class
+    DIRECT_IMPORTS = [
+        DirectImport(
+            importer=Module("mypackage.green"),
+            imported=Module("mypackage.yellow"),
+            line_number=1,
+            line_contents="-",
+        ),
+        DirectImport(
+            importer=Module("mypackage.green"),
+            imported=Module("mypackage.blue"),
+            line_number=1,
+            line_contents="-",
+        ),
+        DirectImport(
+            importer=Module("mypackage.blue"),
+            imported=Module("mypackage.green"),
+            line_number=1,
+            line_contents="-",
+        ),
+        DirectImport(
+            importer=Module("mypackage.blue.cats"),
+            imported=Module("mypackage.purple.dogs"),
+            line_number=1,
+            line_contents="-",
+        ),
+        DirectImport(
+            importer=Module("mypackage.green.cats"),
+            imported=Module("mypackage.orange.dogs"),
+            line_number=1,
+            line_contents="-",
+        ),
+    ]
+
+    def test_succeeds(self):
+        graph = self._build_graph(self.DIRECT_IMPORTS)
+        expressions = [
+            ImportExpression(importer="mypackage.green", imported="mypackage.*"),
+            # Expressions can overlap.
+            ImportExpression(importer="mypackage.green", imported="mypackage.blue"),
+            ImportExpression(importer="mypackage.blue.cats", imported="mypackage.purple.dogs"),
+            # Missing import
+            ImportExpression(importer="mypackage.green", imported="mypackage.black.*"),
+        ]
+
+        # popped_imports: List[Dict[str, Union[str, int]]] = pop_unresolved_import_expressions(
+        popped_imports = pop_unresolved_import_expressions(graph, expressions)
+
+        popped_resolved_imports, popped_unresolved_imports = popped_imports
+
+        # Cast to direct imports to make comparison easier.
+        popped_direct_imports: List[DirectImport] = sorted(
+            map(self._dict_to_direct_import, popped_resolved_imports), key=_direct_import_sort_key
+        )
+        expected_resolved_imports = sorted(
+            [
+                self.DIRECT_IMPORTS[0],
+                self.DIRECT_IMPORTS[1],
+                self.DIRECT_IMPORTS[3],
+            ],
+            key=_direct_import_sort_key,
+        )
+        expected_unresolved_imports = [
+            ImportExpression(importer="mypackage.green", imported="mypackage.black.*")
+        ]
+
+        assert popped_direct_imports == expected_resolved_imports
+        assert popped_unresolved_imports == expected_unresolved_imports
         assert graph.count_imports() == 2
 
     def _build_graph(self, direct_imports):


### PR DESCRIPTION
Adds a `unmatched_ignore_imports_alerting` option to all the contracts to manage the way ignored imports are reported to the user: as error, warning or silenced.

See https://github.com/seddonym/import-linter/issues/114.