### PR TITLE
Ignore missing expressions (#116)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ Latest
 
 * Officially support Python 3.10.
 * Drop support for Python 3.6.
+* Add support for default Field values.
 
 
 1.2.6 (2021-09-24)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,7 @@ Latest
 * Drop support for Python 3.6.
 * Add support for default Field values.
 * Add EnumField.
+* Add unmatched_ignore_imports_alerting option for each contract.
 
 
 1.2.6 (2021-09-24)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,8 +8,8 @@ Latest
 * Drop support for Python 3.6.
 * Add support for default Field values.
 * Add EnumField.
+* Support warnings in contract checks.
 * Add unmatched_ignore_imports_alerting option for each contract.
-
 
 1.2.6 (2021-09-24)
 ------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ Latest
 * Officially support Python 3.10.
 * Drop support for Python 3.6.
 * Add support for default Field values.
+* Add EnumField.
 
 
 1.2.6 (2021-09-24)

--- a/docs/contract_types.rst
+++ b/docs/contract_types.rst
@@ -63,6 +63,7 @@ Configuration options:
       root level external packages (i.e. ``django``, but not ``django.db.models``). If external packages are included,
       the top level configuration must have ``internal_external_packages = True``.
     - ``ignore_imports``: See :ref:`Shared options`.
+    - ``unmatched_ignore_imports_alerting``: See :ref:`Shared options`.
     - ``allow_indirect_imports``: If ``True``, allow indirect imports to forbidden modules without interpreting them
       as a reason to mark the contract broken. (Optional.)
 
@@ -94,6 +95,7 @@ They do this by checking that there are no imports in any direction between the 
 
     - ``modules``: A list of modules/subpackages that should be independent from each other.
     - ``ignore_imports``: See :ref:`Shared options`.
+    - ``unmatched_ignore_imports_alerting``: See :ref:`Shared options`.
 
 
 Layers
@@ -183,6 +185,7 @@ won't complain.
       List of the parent modules of the layers, as *absolute names* that you could import, such as
       ``mypackage.foo``. (Optional.)
     - ``ignore_imports``: See :ref:`Shared options`.
+    - ``unmatched_ignore_imports_alerting``: See :ref:`Shared options`.
 
 
 
@@ -211,3 +214,10 @@ Options used by multiple contracts
   - ``mypackage.*.baz``: matches ``mypackage.foo.baz`` but not ``mypackage.foo.bar.baz``.
   - ``mypackage.*.*``: matches ``mypackage.foo.bar`` and ``mypackage.foobar.baz``.
   - ``mypackage.foo*``: not a valid expression. (The wildcard must replace a whole module name.)
+
+- ``unmatched_ignore_imports_alerting``: The alerting level for handling expressions supplied in ``ignore_imports``
+  that do not match any imports in the graph. Choices are:
+
+    - ``error``: Error if there are any unmatched expressions (default).
+    - ``warn``: Print a warning for each unmatched expression.
+    - ``none``: Do not alert.

--- a/src/importlinter/application/contract_utils.py
+++ b/src/importlinter/application/contract_utils.py
@@ -3,7 +3,14 @@ from typing import Sequence
 from importlinter.application import output
 from importlinter.domain.helpers import MissingImport
 from importlinter.domain.imports import ImportExpression
-from importlinter.domain.output import AlertLevel
+from importlinter.application.contract_utils import AlertLevel
+
+
+@enum.unique
+class AlertLevel(enum.Enum):
+    NONE = "none"
+    WARN = "warn"
+    ERROR = "error"
 
 
 def handle_unresolved_import_expressions(

--- a/src/importlinter/application/contract_utils.py
+++ b/src/importlinter/application/contract_utils.py
@@ -1,5 +1,5 @@
 import enum
-from typing import Optional, Sequence
+from typing import Optional, Sequence, Set
 
 from importlinter.application import output
 from importlinter.domain import helpers
@@ -30,13 +30,16 @@ def remove_ignored_imports(
                             AlertLevel.WARN will warn for each one, and AlertLevel.ERROR will raise
                             an exception for the first one encountered.
     """
-    unresolved = helpers.pop_unresolved_import_expressions(
-        graph, ignore_imports if ignore_imports else []  # type: ignore
-    )[1]
+    imports, unresolved_expressions = helpers.resolve_import_expressions(
+        graph=graph, expressions=ignore_imports if ignore_imports else []
+    )
+
     _handle_unresolved_import_expressions(
-        unresolved,
+        unresolved_expressions,
         unmatched_alerting,  # type: ignore
     )
+
+    helpers.pop_imports(graph, imports)
 
 
 # Private functions
@@ -44,7 +47,7 @@ def remove_ignored_imports(
 
 
 def _handle_unresolved_import_expressions(
-    expressions: Sequence[ImportExpression], alert_level: AlertLevel
+    expressions: Set[ImportExpression], alert_level: AlertLevel
 ) -> None:
     """
     Handle any unresolved import expressions based on the supplied alert level.

--- a/src/importlinter/application/contract_utils.py
+++ b/src/importlinter/application/contract_utils.py
@@ -1,19 +1,49 @@
-from typing import Sequence
+import enum
+from typing import Optional, Sequence
 
 from importlinter.application import output
+from importlinter.domain import helpers
 from importlinter.domain.helpers import MissingImport
 from importlinter.domain.imports import ImportExpression
-from importlinter.application.contract_utils import AlertLevel
+from importlinter.domain.ports.graph import ImportGraph
 
 
-@enum.unique
 class AlertLevel(enum.Enum):
     NONE = "none"
     WARN = "warn"
     ERROR = "error"
 
 
-def handle_unresolved_import_expressions(
+def remove_ignored_imports(
+    graph: ImportGraph,
+    ignore_imports: Optional[Sequence[ImportExpression]],
+    unmatched_alerting: AlertLevel,
+) -> None:
+    """
+    Remove any ignored imports from the graph.
+
+    Args:
+        graph:              The graph that is being checked by a contract.
+        ignore_imports:     Any import expressions that indicate imports to ignore.
+        unmatched_alerting: An AlertLevel that indicates how to handle any import expressions that
+                            don't match any imports. AlertLevel.NONE will ignore them,
+                            AlertLevel.WARN will warn for each one, and AlertLevel.ERROR will raise
+                            an exception for the first one encountered.
+    """
+    unresolved = helpers.pop_unresolved_import_expressions(
+        graph, ignore_imports if ignore_imports else []  # type: ignore
+    )[1]
+    _handle_unresolved_import_expressions(
+        unresolved,
+        unmatched_alerting,  # type: ignore
+    )
+
+
+# Private functions
+# -----------------
+
+
+def _handle_unresolved_import_expressions(
     expressions: Sequence[ImportExpression], alert_level: AlertLevel
 ) -> None:
     """

--- a/src/importlinter/application/contract_utils.py
+++ b/src/importlinter/application/contract_utils.py
@@ -1,0 +1,31 @@
+from typing import Sequence
+
+from importlinter.application import output
+from importlinter.domain.helpers import MissingImport
+from importlinter.domain.imports import ImportExpression
+from importlinter.domain.output import AlertLevel
+
+
+def handle_unresolved_import_expressions(
+    expressions: Sequence[ImportExpression], alert_level: AlertLevel
+) -> None:
+    """
+    Handle any unresolved import expressions based on the supplied alert level.
+
+    Intended to be called while checking a contract.
+    """
+    if alert_level is AlertLevel.NONE:
+        return
+    if not expressions:
+        return
+
+    if alert_level is AlertLevel.WARN:
+        for expression in expressions:
+            output.print_warning(
+                f"Ignored import expression {expression} " "didn't match anything in the graph."
+            )
+    else:  # AlertLevel.ERROR
+        expression_str = sorted(str(expression) for expression in expressions)[0]
+        raise MissingImport(
+            f"Ignored import expression {expression_str} " "didn't match anything in the graph."
+        )

--- a/src/importlinter/application/output.py
+++ b/src/importlinter/application/output.py
@@ -5,7 +5,8 @@ from .ports.printing import Printer
 
 ERROR = "error"
 SUCCESS = "success"
-COLORS = {ERROR: "red", SUCCESS: "green"}
+WARNING = "warning"
+COLORS = {ERROR: "red", SUCCESS: "green", WARNING: "yellow"}
 
 HEADING_LEVEL_ONE = 1
 HEADING_LEVEL_TWO = 2
@@ -95,6 +96,12 @@ class Output:
         """
         self.printer.print(text, color=COLORS[ERROR], bold=bold)
 
+    def print_warning(self, text):
+        """
+        Prints a line to the console, formatted as a warning.
+        """
+        self.printer.print(text, color=COLORS[WARNING])
+
     @property
     def printer(self) -> Printer:
         return settings.PRINTER
@@ -109,3 +116,4 @@ new_line = _instance.new_line
 print_success = _instance.print_success
 print_heading = _instance.print_heading
 print_error = _instance.print_error
+print_warning = _instance.print_warning

--- a/src/importlinter/application/ports/reporting.py
+++ b/src/importlinter/application/ports/reporting.py
@@ -20,6 +20,7 @@ class Report:
         self.contains_failures = False
         self.contracts: List[Contract] = []
         self._check_map: Dict[Contract, ContractCheck] = {}
+        self.warnings_count = 0
         self.broken_count = 0
         self.kept_count = 0
         self.module_count = len(graph.modules)
@@ -28,6 +29,7 @@ class Report:
     def add_contract_check(self, contract: Contract, contract_check: ContractCheck) -> None:
         self.contracts.append(contract)
         self._check_map[contract] = contract_check
+        self.warnings_count += len(contract_check.warnings)
         if contract_check.kept:
             self.kept_count += 1
         else:

--- a/src/importlinter/contracts/forbidden.py
+++ b/src/importlinter/contracts/forbidden.py
@@ -1,9 +1,8 @@
-from typing import Sequence, Tuple, cast
+from typing import Tuple, cast
 
-from importlinter.application import output
+from importlinter.application import contract_utils, output
 from importlinter.domain import fields, helpers
 from importlinter.domain.contract import Contract, ContractCheck
-from importlinter.domain.imports import ImportExpression
 from importlinter.domain.output import AlertLevel
 from importlinter.domain.ports.graph import ImportGraph
 
@@ -43,7 +42,7 @@ class ForbiddenContract(Contract):
             graph, self.ignore_imports if self.ignore_imports else []  # type: ignore
         )
 
-        self._check_unresolved_imports(
+        contract_utils.handle_unresolved_import_expressions(
             unresolved,
             self.unmatched_ignore_imports_alerting,  # type: ignore
         )
@@ -147,31 +146,3 @@ class ForbiddenContract(Contract):
 
     def _graph_was_built_with_externals(self) -> bool:
         return str(self.session_options.get("include_external_packages")).lower() == "true"
-
-    def _check_unresolved_imports(
-        self, unresolved_imports: Sequence[ImportExpression], alert_level: AlertLevel
-    ) -> None:
-        if len(unresolved_imports) == 0 or alert_level == AlertLevel.NONE:
-            # Skip if no unresolved imports or no alerting
-            return
-
-        elif alert_level == AlertLevel.WARN:
-            # Print warnings for each unresolved import
-            for unresolved_import in unresolved_imports:
-                output.print_warning(
-                    f"Ignored import expression {unresolved_import} "
-                    "didn't match anything in the graph."
-                )
-            return
-
-        else:
-            # Raise exception for first unresolved import
-            unresolved_imports_str = (
-                str(unresolved_import) for unresolved_import in unresolved_imports
-            )
-            unresolved_import_str = sorted(unresolved_imports_str)[0]
-
-            raise ValueError(
-                f"Ignored import expression {unresolved_import_str} "
-                "didn't match anything in the graph."
-            )

--- a/src/importlinter/contracts/forbidden.py
+++ b/src/importlinter/contracts/forbidden.py
@@ -1,9 +1,9 @@
 from typing import Tuple, cast
 
 from importlinter.application import contract_utils, output
+from importlinter.application.contract_utils import AlertLevel
 from importlinter.domain import fields, helpers
 from importlinter.domain.contract import Contract, ContractCheck
-from importlinter.domain.output import AlertLevel
 from importlinter.domain.ports.graph import ImportGraph
 
 

--- a/src/importlinter/contracts/forbidden.py
+++ b/src/importlinter/contracts/forbidden.py
@@ -36,7 +36,7 @@ class ForbiddenContract(Contract):
         is_kept = True
         invalid_chains = []
 
-        contract_utils.remove_ignored_imports(
+        warnings = contract_utils.remove_ignored_imports(
             graph=graph,
             ignore_imports=self.ignore_imports,  # type: ignore
             unmatched_alerting=self.unmatched_ignore_imports_alerting,  # type: ignore
@@ -94,7 +94,9 @@ class ForbiddenContract(Contract):
                 if subpackage_chain_data["chains"]:
                     invalid_chains.append(subpackage_chain_data)
 
-        return ContractCheck(kept=is_kept, metadata={"invalid_chains": invalid_chains})
+        return ContractCheck(
+            kept=is_kept, warnings=warnings, metadata={"invalid_chains": invalid_chains}
+        )
 
     def render_broken_contract(self, check: "ContractCheck") -> None:
         count = 0

--- a/src/importlinter/contracts/independence.py
+++ b/src/importlinter/contracts/independence.py
@@ -1,9 +1,9 @@
 from itertools import permutations
 
 from importlinter.application import contract_utils, output
+from importlinter.application.contract_utils import AlertLevel
 from importlinter.domain import fields, helpers
 from importlinter.domain.contract import Contract, ContractCheck
-from importlinter.domain.output import AlertLevel
 from importlinter.domain.ports.graph import ImportGraph
 
 

--- a/src/importlinter/contracts/independence.py
+++ b/src/importlinter/contracts/independence.py
@@ -1,10 +1,8 @@
 from itertools import permutations
-from typing import Sequence
 
-from importlinter.application import output
+from importlinter.application import contract_utils, output
 from importlinter.domain import fields, helpers
 from importlinter.domain.contract import Contract, ContractCheck
-from importlinter.domain.imports import ImportExpression
 from importlinter.domain.output import AlertLevel
 from importlinter.domain.ports.graph import ImportGraph
 
@@ -43,7 +41,7 @@ class IndependenceContract(Contract):
             graph, self.ignore_imports if self.ignore_imports else []  # type: ignore
         )
 
-        self._check_unresolved_imports(
+        contract_utils.handle_unresolved_import_expressions(
             unresolved,
             self.unmatched_ignore_imports_alerting,  # type: ignore
         )
@@ -113,31 +111,3 @@ class IndependenceContract(Contract):
         for module in self.modules:  # type: ignore
             if module.name not in graph.modules:
                 raise ValueError(f"Module '{module.name}' does not exist.")
-
-    def _check_unresolved_imports(
-        self, unresolved_imports: Sequence[ImportExpression], alert_level: AlertLevel
-    ) -> None:
-        if len(unresolved_imports) == 0 or alert_level == AlertLevel.NONE:
-            # Skip if no unresolved imports or no alerting
-            return
-
-        elif alert_level == AlertLevel.WARN:
-            # Print warnings for each unresolved import
-            for unresolved_import in unresolved_imports:
-                output.print_warning(
-                    f"Ignored import expression {unresolved_import} "
-                    "didn't match anything in the graph."
-                )
-            return
-
-        else:
-            # Raise exception for first unresolved import
-            unresolved_imports_str = (
-                str(unresolved_import) for unresolved_import in unresolved_imports
-            )
-            unresolved_import_str = sorted(unresolved_imports_str)[0]
-
-            raise ValueError(
-                f"Ignored import expression {unresolved_import_str} "
-                "didn't match anything in the graph."
-            )

--- a/src/importlinter/contracts/independence.py
+++ b/src/importlinter/contracts/independence.py
@@ -35,7 +35,7 @@ class IndependenceContract(Contract):
         is_kept = True
         invalid_chains = []
 
-        contract_utils.remove_ignored_imports(
+        warnings = contract_utils.remove_ignored_imports(
             graph=graph,
             ignore_imports=self.ignore_imports,  # type: ignore
             unmatched_alerting=self.unmatched_ignore_imports_alerting,  # type: ignore
@@ -75,7 +75,9 @@ class IndependenceContract(Contract):
             if subpackage_chain_data["chains"]:
                 invalid_chains.append(subpackage_chain_data)
 
-        return ContractCheck(kept=is_kept, metadata={"invalid_chains": invalid_chains})
+        return ContractCheck(
+            kept=is_kept, warnings=warnings, metadata={"invalid_chains": invalid_chains}
+        )
 
     def render_broken_contract(self, check: "ContractCheck") -> None:
         count = 0

--- a/src/importlinter/contracts/layers.py
+++ b/src/importlinter/contracts/layers.py
@@ -5,7 +5,6 @@ from importlinter.application import contract_utils, output
 from importlinter.domain import fields, helpers
 from importlinter.domain.contract import Contract, ContractCheck
 from importlinter.domain.imports import Module
-from importlinter.domain.output import AlertLevel
 from importlinter.domain.ports.graph import ImportGraph
 
 

--- a/src/importlinter/contracts/layers.py
+++ b/src/importlinter/contracts/layers.py
@@ -1,10 +1,10 @@
 import copy
-from typing import Any, Dict, Iterator, List, Optional, Sequence, Tuple, Union
+from typing import Any, Dict, Iterator, List, Optional, Tuple, Union
 
-from importlinter.application import output
+from importlinter.application import contract_utils, output
 from importlinter.domain import fields, helpers
 from importlinter.domain.contract import Contract, ContractCheck
-from importlinter.domain.imports import ImportExpression, Module
+from importlinter.domain.imports import Module
 from importlinter.domain.output import AlertLevel
 from importlinter.domain.ports.graph import ImportGraph
 
@@ -70,7 +70,7 @@ class LayersContract(Contract):
             direct_imports_to_ignore,  # type: ignore
         )
 
-        self._check_unresolved_imports(
+        contract_utils.handle_unresolved_import_expressions(
             unresolved,
             self.unmatched_ignore_imports_alerting,  # type: ignore
         )
@@ -453,31 +453,3 @@ class LayersContract(Contract):
                     import_details_list.append(import_details)
                     graph.remove_import(importer=lower_layer_module, imported=imported_module)
         return import_details_list
-
-    def _check_unresolved_imports(
-        self, unresolved_imports: Sequence[ImportExpression], alert_level: AlertLevel
-    ) -> None:
-        if len(unresolved_imports) == 0 or alert_level == AlertLevel.NONE:
-            # Skip if no unresolved imports or no alerting
-            return
-
-        elif alert_level == AlertLevel.WARN:
-            # Print warnings for each unresolved import
-            for unresolved_import in unresolved_imports:
-                output.print_warning(
-                    f"Ignored import expression {unresolved_import} "
-                    "didn't match anything in the graph."
-                )
-            return
-
-        else:
-            # Raise exception for first unresolved import
-            unresolved_imports_str = (
-                str(unresolved_import) for unresolved_import in unresolved_imports
-            )
-            unresolved_import_str = sorted(unresolved_imports_str)[0]
-
-            raise helpers.MissingImport(
-                f"Ignored import expression {unresolved_import_str} "
-                "didn't match anything in the graph."
-            )

--- a/src/importlinter/contracts/layers.py
+++ b/src/importlinter/contracts/layers.py
@@ -1,10 +1,11 @@
 import copy
-from typing import Any, Dict, Iterator, List, Optional, Tuple, Union
+from typing import Any, Dict, Iterator, List, Optional, Sequence, Tuple, Union
 
 from importlinter.application import output
 from importlinter.domain import fields, helpers
 from importlinter.domain.contract import Contract, ContractCheck
-from importlinter.domain.imports import Module
+from importlinter.domain.imports import ImportExpression, Module
+from importlinter.domain.output import AlertLevel
 from importlinter.domain.ports.graph import ImportGraph
 
 
@@ -45,6 +46,9 @@ class LayersContract(Contract):
         - ignore_imports: A set of ImportExpressions. These imports will be ignored: if the import
                           would cause a contract to be broken, adding it to the set will cause
                           the contract be kept instead. (Optional.)
+        - unmatched_ignore_imports_alerting: Decides how to report when the expression in the
+                          `ignore_imports` set is not found in the graph. Valid values are
+                          "none", "warn", "error". Default value is "error".
     """
 
     type_name = "layers"
@@ -52,13 +56,24 @@ class LayersContract(Contract):
     layers = fields.ListField(subfield=LayerField())
     containers = fields.ListField(subfield=fields.StringField(), required=False)
     ignore_imports = fields.SetField(subfield=fields.ImportExpressionField(), required=False)
+    unmatched_ignore_imports_alerting = fields.EnumField(
+        AlertLevel, default=AlertLevel.ERROR, required=False
+    )
 
     def check(self, graph: ImportGraph) -> ContractCheck:
         is_kept = True
         invalid_chains = []
-
         direct_imports_to_ignore = self.ignore_imports if self.ignore_imports else []
-        helpers.pop_import_expressions(graph, direct_imports_to_ignore)  # type: ignore
+
+        _, unresolved = helpers.pop_unresolved_import_expressions(
+            graph,
+            direct_imports_to_ignore,  # type: ignore
+        )
+
+        self._check_unresolved_imports(
+            unresolved,
+            self.unmatched_ignore_imports_alerting,  # type: ignore
+        )
 
         if self.containers:
             self._validate_containers(graph)
@@ -438,3 +453,31 @@ class LayersContract(Contract):
                     import_details_list.append(import_details)
                     graph.remove_import(importer=lower_layer_module, imported=imported_module)
         return import_details_list
+
+    def _check_unresolved_imports(
+        self, unresolved_imports: Sequence[ImportExpression], alert_level: AlertLevel
+    ) -> None:
+        if len(unresolved_imports) == 0 or alert_level == AlertLevel.NONE:
+            # Skip if no unresolved imports or no alerting
+            return
+
+        elif alert_level == AlertLevel.WARN:
+            # Print warnings for each unresolved import
+            for unresolved_import in unresolved_imports:
+                output.print_warning(
+                    f"Ignored import expression {unresolved_import} "
+                    "didn't match anything in the graph."
+                )
+            return
+
+        else:
+            # Raise exception for first unresolved import
+            unresolved_imports_str = (
+                str(unresolved_import) for unresolved_import in unresolved_imports
+            )
+            unresolved_import_str = sorted(unresolved_imports_str)[0]
+
+            raise ValueError(
+                f"Ignored import expression {unresolved_import_str} "
+                "didn't match anything in the graph."
+            )

--- a/src/importlinter/contracts/layers.py
+++ b/src/importlinter/contracts/layers.py
@@ -477,7 +477,7 @@ class LayersContract(Contract):
             )
             unresolved_import_str = sorted(unresolved_imports_str)[0]
 
-            raise ValueError(
+            raise helpers.MissingImport(
                 f"Ignored import expression {unresolved_import_str} "
                 "didn't match anything in the graph."
             )

--- a/src/importlinter/contracts/layers.py
+++ b/src/importlinter/contracts/layers.py
@@ -62,7 +62,7 @@ class LayersContract(Contract):
         is_kept = True
         invalid_chains = []
 
-        contract_utils.remove_ignored_imports(
+        warnings = contract_utils.remove_ignored_imports(
             graph=graph,
             ignore_imports=self.ignore_imports,  # type: ignore
             unmatched_alerting=self.unmatched_ignore_imports_alerting,  # type: ignore
@@ -89,7 +89,9 @@ class LayersContract(Contract):
                 is_kept = False
                 invalid_chains.append(layer_chain_data)
 
-        return ContractCheck(kept=is_kept, metadata={"invalid_chains": invalid_chains})
+        return ContractCheck(
+            kept=is_kept, warnings=warnings, metadata={"invalid_chains": invalid_chains}
+        )
 
     def render_broken_contract(self, check: ContractCheck) -> None:
         for chains_data in check.metadata["invalid_chains"]:

--- a/src/importlinter/domain/contract.py
+++ b/src/importlinter/domain/contract.py
@@ -85,9 +85,15 @@ class ContractCheck:
     Data class to store the result of checking a contract.
     """
 
-    def __init__(self, kept: bool, metadata: Optional[Dict[str, Any]] = None) -> None:
+    def __init__(
+        self,
+        kept: bool,
+        metadata: Optional[Dict[str, Any]] = None,
+        warnings: Optional[List[str]] = None,
+    ) -> None:
         self.kept = kept
-        self.metadata = metadata if metadata else {}
+        self.metadata = metadata or {}
+        self.warnings = warnings or []
 
 
 class NoSuchContractType(Exception):

--- a/src/importlinter/domain/contract.py
+++ b/src/importlinter/domain/contract.py
@@ -29,7 +29,9 @@ class Contract(abc.ABC):
             try:
                 raw_data = self.contract_options[field_name]
             except KeyError:
-                if field.required:
+                if field.default is not fields.NotSupplied:
+                    setattr(self, field_name, field.default)
+                elif field.required:
                     errors[field_name] = "This is a required field."
                 else:
                     setattr(self, field_name, None)

--- a/src/importlinter/domain/fields.py
+++ b/src/importlinter/domain/fields.py
@@ -1,5 +1,6 @@
 import abc
-from typing import Generic, Iterable, List, Set, TypeVar, Union
+from enum import Enum
+from typing import Generic, Iterable, List, Set, Type, TypeVar, Union
 
 from importlinter.domain.imports import Module, ImportExpression
 
@@ -136,3 +137,27 @@ class ImportExpressionField(Field):
         for part in expression.split("."):
             if len(part) > 1 and "*" in part:
                 raise ValidationError("A wildcard can only replace a whole module.")
+
+
+class EnumField(Field):
+    """ """
+
+    def __init__(self, enum: Type[Enum], default: Enum, required: bool = True) -> None:
+        super().__init__(required)
+
+        self._enum = enum
+        self._default = default
+
+    def parse(self, raw_data: Union[str, List[str]]) -> Enum:
+        string = StringField().parse(raw_data).strip()
+
+        if string == "":
+            return self._default
+
+        try:
+            return self._enum[string.upper()]
+        except KeyError:
+            raise ValidationError(
+                f"Invalid value `{string}` "
+                f"must be one of {[member.value for member in self._enum]}"
+            )

--- a/src/importlinter/domain/helpers.py
+++ b/src/importlinter/domain/helpers.py
@@ -99,39 +99,24 @@ def import_expressions_to_imports(
 
 def resolve_import_expressions(
     graph: ImportGraph, expressions: Iterable[ImportExpression]
-) -> Tuple[List[DirectImport], List[ImportExpression]]:
+) -> Tuple[Set[DirectImport], Set[ImportExpression]]:
     """
     Find any imports in the graph that match the supplied import expressions.
 
     Returns tuple of:
-        - List of resolved imports.
-        - List of import expressions that didn't match any imports.
+        - Set of resolved imports.
+        - Set of import expressions that didn't match any imports.
     """
     resolved_imports = set()
-    unresolved_imports = set()
+    unresolved_expressions = set()
 
     for expression in expressions:
         try:
             resolved_imports.update(import_expression_to_imports(graph, expression))
         except MissingImport:
-            unresolved_imports.add(expression)
+            unresolved_expressions.add(expression)
 
-    return (list(resolved_imports), list(unresolved_imports))
-
-
-def pop_unresolved_import_expressions(
-    graph: ImportGraph, expressions: Iterable[ImportExpression]
-) -> Tuple[List[Dict[str, Union[str, int]]], List[ImportExpression]]:
-    """
-    Remove any imports matching the supplied import expressions from the graph.
-
-    Returns tuple with:
-        - List of imports that were removed, including any additional metadata.
-        - List of any import expressions that did not match any imports.
-    """
-    resolved_imports, unresolved_imports = resolve_import_expressions(graph, expressions)
-
-    return (pop_imports(graph, resolved_imports), unresolved_imports)
+    return (resolved_imports, unresolved_expressions)
 
 
 def pop_import_expressions(

--- a/src/importlinter/domain/helpers.py
+++ b/src/importlinter/domain/helpers.py
@@ -119,11 +119,11 @@ def pop_unresolved_import_expressions(
     graph: ImportGraph, expressions: Iterable[ImportExpression]
 ) -> Tuple[List[Dict[str, Union[str, int]]], List[ImportExpression]]:
     """
-    Removes any imports matching the supplied import expressions from the graph.
+    Remove any imports matching the supplied import expressions from the graph.
 
-    Returns:
-        A tuple with the list of imports that were removed, including any additional metadata,
-        and the list of unresolved imports.
+    Returns tuple with:
+        - List of imports that were removed, including any additional metadata.
+        - List of any import expressions that did not match any imports.
     """
     resolved_imports, unresolved_imports = unresolved_import_expressions_to_imports(
         graph, expressions

--- a/src/importlinter/domain/helpers.py
+++ b/src/importlinter/domain/helpers.py
@@ -97,11 +97,15 @@ def import_expressions_to_imports(
     )
 
 
-def unresolved_import_expressions_to_imports(
+def resolve_import_expressions(
     graph: ImportGraph, expressions: Iterable[ImportExpression]
 ) -> Tuple[List[DirectImport], List[ImportExpression]]:
     """
-    Returns a tuple of imports in a graph and unresolved imports, given some import expressions.
+    Find any imports in the graph that match the supplied import expressions.
+
+    Returns tuple of:
+        - List of resolved imports.
+        - List of import expressions that didn't match any imports.
     """
     resolved_imports = set()
     unresolved_imports = set()
@@ -125,9 +129,7 @@ def pop_unresolved_import_expressions(
         - List of imports that were removed, including any additional metadata.
         - List of any import expressions that did not match any imports.
     """
-    resolved_imports, unresolved_imports = unresolved_import_expressions_to_imports(
-        graph, expressions
-    )
+    resolved_imports, unresolved_imports = resolve_import_expressions(graph, expressions)
 
     return (pop_imports(graph, resolved_imports), unresolved_imports)
 

--- a/src/importlinter/domain/output.py
+++ b/src/importlinter/domain/output.py
@@ -1,0 +1,8 @@
+import enum
+
+
+@enum.unique
+class AlertLevel(enum.Enum):
+    NONE = "none"
+    WARN = "warn"
+    ERROR = "error"

--- a/src/importlinter/domain/output.py
+++ b/src/importlinter/domain/output.py
@@ -1,8 +1,0 @@
-import enum
-
-
-@enum.unique
-class AlertLevel(enum.Enum):
-    NONE = "none"
-    WARN = "warn"
-    ERROR = "error"

--- a/tests/assets/testpackage/unmatched_ignore_imports_alerting/error.ini
+++ b/tests/assets/testpackage/unmatched_ignore_imports_alerting/error.ini
@@ -1,0 +1,13 @@
+[importlinter]
+root_package = testpackage
+
+[importlinter:contract:one]
+name=Test independence contract
+type=independence
+modules=
+    testpackage.high.blue
+    testpackage.high.green
+ignore_imports=
+    testpackage.utils -> testpackage.high.green
+    testpackage.*.blue.* -> testpackage.indirect.*
+    testpackage.nonexistent -> testpackage.high.green

--- a/tests/assets/testpackage/unmatched_ignore_imports_alerting/none.ini
+++ b/tests/assets/testpackage/unmatched_ignore_imports_alerting/none.ini
@@ -1,0 +1,14 @@
+[importlinter]
+root_package = testpackage
+
+[importlinter:contract:one]
+name=Test independence contract
+type=independence
+modules=
+    testpackage.high.blue
+    testpackage.high.green
+ignore_imports=
+    testpackage.utils -> testpackage.high.green
+    testpackage.*.blue.* -> testpackage.indirect.*
+    testpackage.nonexistent -> testpackage.high.green
+unmatched_ignore_imports_alerting = none

--- a/tests/assets/testpackage/unmatched_ignore_imports_alerting/unspecified.ini
+++ b/tests/assets/testpackage/unmatched_ignore_imports_alerting/unspecified.ini
@@ -1,0 +1,14 @@
+[importlinter]
+root_package = testpackage
+
+[importlinter:contract:one]
+name=Test independence contract
+type=independence
+modules=
+    testpackage.high.blue
+    testpackage.high.green
+ignore_imports=
+    testpackage.utils -> testpackage.high.green
+    testpackage.*.blue.* -> testpackage.indirect.*
+    testpackage.nonexistent -> testpackage.high.green
+unmatched_ignore_imports_alerting = error

--- a/tests/assets/testpackage/unmatched_ignore_imports_alerting/warn.ini
+++ b/tests/assets/testpackage/unmatched_ignore_imports_alerting/warn.ini
@@ -1,0 +1,14 @@
+[importlinter]
+root_package = testpackage
+
+[importlinter:contract:one]
+name=Test independence contract
+type=independence
+modules=
+    testpackage.high.blue
+    testpackage.high.green
+ignore_imports=
+    testpackage.utils -> testpackage.high.green
+    testpackage.*.blue.* -> testpackage.indirect.*
+    testpackage.nonexistent -> testpackage.high.green
+unmatched_ignore_imports_alerting = warn

--- a/tests/functional/test_lint_imports.py
+++ b/tests/functional/test_lint_imports.py
@@ -6,8 +6,11 @@ import pytest
 from importlinter import cli
 
 this_directory = Path(__file__).parent
-testpackage_directory = this_directory / ".." / "assets" / "testpackage"
-multipleroots_directory = this_directory / ".." / "assets" / "multipleroots"
+assets_directory = this_directory / ".." / "assets"
+
+testpackage_directory = assets_directory / "testpackage"
+multipleroots_directory = assets_directory / "multipleroots"
+unmatched_ignore_imports_directory = testpackage_directory / "unmatched_ignore_imports_alerting"
 
 
 @pytest.mark.parametrize(
@@ -63,6 +66,28 @@ multipleroots_directory = this_directory / ".." / "assets" / "multipleroots"
             ".externalkeptcontract.toml",
             cli.EXIT_STATUS_SUCCESS,
             marks=pytest.mark.toml_installed,
+        ),
+        # Unmatched ignore imports alerting.
+        # The return value depends on what this is set to.
+        (
+            testpackage_directory,
+            str(unmatched_ignore_imports_directory / "unspecified.ini"),
+            cli.EXIT_STATUS_ERROR,
+        ),
+        (
+            testpackage_directory,
+            str(unmatched_ignore_imports_directory / "error.ini"),
+            cli.EXIT_STATUS_ERROR,
+        ),
+        (
+            testpackage_directory,
+            str(unmatched_ignore_imports_directory / "warn.ini"),
+            cli.EXIT_STATUS_SUCCESS,
+        ),
+        (
+            testpackage_directory,
+            str(unmatched_ignore_imports_directory / "none.ini"),
+            cli.EXIT_STATUS_SUCCESS,
         ),
     ),
 )

--- a/tests/functional/test_lint_imports.py
+++ b/tests/functional/test_lint_imports.py
@@ -1,11 +1,13 @@
 import os
+from pathlib import Path
 
 import pytest
 
 from importlinter import cli
 
-testpackage_directory = os.path.join(os.path.dirname(__file__), "..", "assets", "testpackage")
-multipleroots_directory = os.path.join(os.path.dirname(__file__), "..", "assets", "multipleroots")
+this_directory = Path(__file__).parent
+testpackage_directory = this_directory / ".." / "assets" / "testpackage"
+multipleroots_directory = this_directory / ".." / "assets" / "multipleroots"
 
 
 @pytest.mark.parametrize(

--- a/tests/helpers/contracts.py
+++ b/tests/helpers/contracts.py
@@ -5,8 +5,10 @@ from importlinter.domain.ports.graph import ImportGraph
 
 
 class AlwaysPassesContract(Contract):
+    warnings = fields.ListField(subfield=fields.StringField(), required=False)
+
     def check(self, graph: ImportGraph) -> ContractCheck:
-        return ContractCheck(kept=True)
+        return ContractCheck(kept=True, warnings=self.warnings)  # type: ignore
 
     def render_broken_contract(self, check: "ContractCheck") -> None:
         # No need to implement, will never fail.
@@ -14,8 +16,10 @@ class AlwaysPassesContract(Contract):
 
 
 class AlwaysFailsContract(Contract):
+    warnings = fields.ListField(subfield=fields.StringField(), required=False)
+
     def check(self, graph: ImportGraph) -> ContractCheck:
-        return ContractCheck(kept=False)
+        return ContractCheck(kept=False, warnings=self.warnings)  # type: ignore
 
     def render_broken_contract(self, check: "ContractCheck") -> None:
         output.print("This contract will always fail.")

--- a/tests/unit/application/test_contract_utils.py
+++ b/tests/unit/application/test_contract_utils.py
@@ -1,0 +1,106 @@
+import pytest
+from grimp.adaptors.graph import ImportGraph  # type: ignore
+
+from importlinter.application.contract_utils import AlertLevel, remove_ignored_imports
+from importlinter.domain.helpers import MissingImport
+from importlinter.domain.imports import DirectImport, ImportExpression, Module
+
+
+class TestRemoveIgnoredImports:
+    DIRECT_IMPORTS = [
+        DirectImport(
+            importer=Module("mypackage.green"),
+            imported=Module("mypackage.yellow"),
+            line_number=1,
+            line_contents="-",
+        ),
+        DirectImport(
+            importer=Module("mypackage.green"),
+            imported=Module("mypackage.purple"),
+            line_number=1,
+            line_contents="-",
+        ),
+        DirectImport(
+            importer=Module("mypackage.green"),
+            imported=Module("mypackage.blue"),
+            line_number=1,
+            line_contents="-",
+        ),
+        DirectImport(  # Direct Imports can appear twice, for different line numbers.
+            importer=Module("mypackage.green"),
+            imported=Module("mypackage.blue"),
+            line_number=2,
+            line_contents="-",
+        ),
+    ]
+
+    @pytest.mark.parametrize("alert_level", [AlertLevel.NONE, AlertLevel.WARN, AlertLevel.ERROR])
+    def test_no_unresolved_import_expressions(self, alert_level):
+        graph = self._build_graph(self.DIRECT_IMPORTS)
+
+        warnings = remove_ignored_imports(
+            graph=graph,
+            ignore_imports=[
+                ImportExpression(importer="mypackage.green", imported="mypackage.blue"),
+                ImportExpression(importer="mypackage.green", imported="mypackage.purple"),
+            ],
+            unmatched_alerting=alert_level,
+        )
+
+        assert graph.count_imports() == 1  # The three matching imports have been removed.
+        assert warnings == []
+
+    @pytest.mark.parametrize(
+        "alert_level, expected_result",
+        [
+            (AlertLevel.NONE, []),
+            (
+                AlertLevel.WARN,
+                [
+                    "No matches for ignored import mypackage.* -> mypackage.nonexistent.",
+                    "No matches for ignored import mypackage.nonexistent -> mypackage.blue.",
+                ],
+            ),
+            (
+                AlertLevel.ERROR,
+                MissingImport(
+                    "No matches for ignored import mypackage.* -> mypackage.nonexistent."
+                ),
+            ),
+        ],
+    )
+    def test_unresolved_import_expressions(self, alert_level, expected_result):
+        graph = self._build_graph(self.DIRECT_IMPORTS)
+        ignore_imports = [
+            ImportExpression(importer="mypackage.green", imported="mypackage.blue"),
+            ImportExpression(importer="mypackage.*", imported="mypackage.nonexistent"),
+            ImportExpression(importer="mypackage.green", imported="mypackage.purple"),
+            ImportExpression(importer="mypackage.nonexistent", imported="mypackage.blue"),
+        ]
+
+        if isinstance(expected_result, Exception):
+            with pytest.raises(type(expected_result), match=str(expected_result)):
+                remove_ignored_imports(
+                    graph=graph,
+                    ignore_imports=ignore_imports,
+                    unmatched_alerting=alert_level,
+                )
+        else:
+            warnings = remove_ignored_imports(
+                graph=graph,
+                ignore_imports=ignore_imports,
+                unmatched_alerting=alert_level,
+            )
+            assert graph.count_imports() == 1  # The three matching imports have been removed.
+            assert set(warnings) == set(expected_result)
+
+    def _build_graph(self, direct_imports):
+        graph = ImportGraph()
+        for direct_import in direct_imports:
+            graph.add_import(
+                importer=direct_import.importer.name,
+                imported=direct_import.imported.name,
+                line_number=direct_import.line_number,
+                line_contents=direct_import.line_contents,
+            )
+        return graph

--- a/tests/unit/application/test_use_cases.py
+++ b/tests/unit/application/test_use_cases.py
@@ -114,6 +114,67 @@ class TestCheckContractsAndPrintReport:
             """
         )
 
+    def test_warnings(self):
+        self._configure(
+            contracts_options=[
+                {
+                    "type": "always_passes",
+                    "name": "Contract foo",
+                    "warnings": ["Some warning.", "Another warning."],
+                },
+                {"type": "always_fails", "name": "Contract bar", "warnings": ["A third warning."]},
+            ]
+        )
+
+        result = lint_imports()
+
+        assert result == FAILURE
+
+        settings.PRINTER.pop_and_assert(
+            """
+            =============
+            Import Linter
+            =============
+
+            ---------
+            Contracts
+            ---------
+
+            Analyzed 26 files, 10 dependencies.
+            -----------------------------------
+
+            Contract foo KEPT (2 warnings)
+            Contract bar BROKEN (1 warning)
+
+            Contracts: 1 kept, 1 broken.
+
+            --------
+            Warnings
+            --------
+
+            Contract foo
+            ------------
+
+            - Some warning.
+            - Another warning.
+
+            Contract bar
+            ------------
+
+            - A third warning.
+
+
+            ----------------
+            Broken contracts
+            ----------------
+
+            Contract bar
+            ------------
+
+            This contract will always fail.
+            """
+        )
+
     def test_forbidden_import(self):
         """
         Tests the ForbiddenImportContract - a simple contract that

--- a/tests/unit/contracts/test_forbidden.py
+++ b/tests/unit/contracts/test_forbidden.py
@@ -181,6 +181,29 @@ class TestForbiddenContract:
 
         assert contract_check.kept == contract_is_kept
 
+    def test_ignore_imports_adds_warnings(self):
+        graph = self._build_graph()
+        contract = ForbiddenContract(
+            name="Forbid contract",
+            session_options={"root_packages": ["mypackage"]},
+            contract_options={
+                "source_modules": ("mypackage.one", "mypackage.two", "mypackage.three"),
+                "forbidden_modules": "mypackage.purple",
+                "ignore_imports": [
+                    "mypackage.one -> mypackage.two.nonexistent",
+                    "mypackage.*.nonexistent -> mypackage.three",
+                ],
+                "unmatched_ignore_imports_alerting": "warn",
+            },
+        )
+
+        contract_check = contract.check(graph=graph)
+
+        assert set(contract_check.warnings) == {
+            "No matches for ignored import mypackage.one -> mypackage.two.nonexistent.",
+            "No matches for ignored import mypackage.*.nonexistent -> mypackage.three.",
+        }
+
     def _build_graph(self):
         graph = ImportGraph()
         for module in (

--- a/tests/unit/contracts/test_layers.py
+++ b/tests/unit/contracts/test_layers.py
@@ -769,11 +769,12 @@ class TestIgnoreImports:
             "mypackage.nonexistent.* -> mypackage.high",
         ],
     )
-    def test_ignore_from_nonexistent_importer_raises_missing_import(self, expression):
+    def test_ignore_from_nonexistent_importer_raises_value(self, expression):
         contract = self._build_contract(ignore_imports=[expression])
         graph = self._build_graph()
+        message = f"Ignored import expression {expression} didn't match anything in the graph."
 
-        with pytest.raises(MissingImport):
+        with pytest.raises(ValueError, match=message):
             contract.check(graph=graph)
 
     @pytest.mark.parametrize(
@@ -783,11 +784,12 @@ class TestIgnoreImports:
             "mypackage.high -> mypackage.nonexistent.*",
         ],
     )
-    def test_ignore_from_nonexistent_imported_raises_missing_import(self, expression):
+    def test_ignore_from_nonexistent_imported_raises_value(self, expression):
         contract = self._build_contract(ignore_imports=[expression])
         graph = self._build_graph()
+        message = f"Ignored import expression {expression} didn't match anything in the graph."
 
-        with pytest.raises(MissingImport):
+        with pytest.raises(ValueError, match=message):
             contract.check(graph=graph)
 
     def test_ignore_imports_tolerates_duplicates(self):

--- a/tests/unit/contracts/test_layers.py
+++ b/tests/unit/contracts/test_layers.py
@@ -806,6 +806,29 @@ class TestIgnoreImports:
 
         assert contract_check.kept
 
+    def test_ignore_imports_adds_warnings(self):
+        contract = LayersContract(
+            name="Layer contract",
+            session_options={"root_packages": ["mypackage"]},
+            contract_options={
+                "containers": ["mypackage"],
+                "layers": ["high", "medium", "low"],
+                "ignore_imports": [
+                    "mypackage.high -> mypackage.nonexistent.*",
+                    "mypackage.high -> mypackage.nonexistent.foo",
+                ],
+                "unmatched_ignore_imports_alerting": "warn",
+            },
+        )
+        graph = self._build_graph()
+
+        contract_check = contract.check(graph=graph)
+
+        assert set(contract_check.warnings) == {
+            "No matches for ignored import mypackage.high -> mypackage.nonexistent.*.",
+            "No matches for ignored import mypackage.high -> mypackage.nonexistent.foo.",
+        }
+
     def _build_graph(self):
         graph = ImportGraph()
         for module in (

--- a/tests/unit/contracts/test_layers.py
+++ b/tests/unit/contracts/test_layers.py
@@ -772,7 +772,7 @@ class TestIgnoreImports:
     def test_ignore_from_nonexistent_importer_raises_missing_import(self, expression):
         contract = self._build_contract(ignore_imports=[expression])
         graph = self._build_graph()
-        message = f"Ignored import expression {expression} didn't match anything in the graph."
+        message = f"No matches for ignored import {expression}."
 
         with pytest.raises(MissingImport, match=message):
             contract.check(graph=graph)
@@ -787,7 +787,7 @@ class TestIgnoreImports:
     def test_ignore_from_nonexistent_imported_raises_missing_import(self, expression):
         contract = self._build_contract(ignore_imports=[expression])
         graph = self._build_graph()
-        message = f"Ignored import expression {expression} didn't match anything in the graph."
+        message = f"No matches for ignored import {expression}."
 
         with pytest.raises(MissingImport, match=message):
             contract.check(graph=graph)

--- a/tests/unit/contracts/test_layers.py
+++ b/tests/unit/contracts/test_layers.py
@@ -769,12 +769,12 @@ class TestIgnoreImports:
             "mypackage.nonexistent.* -> mypackage.high",
         ],
     )
-    def test_ignore_from_nonexistent_importer_raises_value(self, expression):
+    def test_ignore_from_nonexistent_importer_raises_missing_import(self, expression):
         contract = self._build_contract(ignore_imports=[expression])
         graph = self._build_graph()
         message = f"Ignored import expression {expression} didn't match anything in the graph."
 
-        with pytest.raises(ValueError, match=message):
+        with pytest.raises(MissingImport, match=message):
             contract.check(graph=graph)
 
     @pytest.mark.parametrize(
@@ -784,12 +784,12 @@ class TestIgnoreImports:
             "mypackage.high -> mypackage.nonexistent.*",
         ],
     )
-    def test_ignore_from_nonexistent_imported_raises_value(self, expression):
+    def test_ignore_from_nonexistent_imported_raises_missing_import(self, expression):
         contract = self._build_contract(ignore_imports=[expression])
         graph = self._build_graph()
         message = f"Ignored import expression {expression} didn't match anything in the graph."
 
-        with pytest.raises(ValueError, match=message):
+        with pytest.raises(MissingImport, match=message):
             contract.check(graph=graph)
 
     def test_ignore_imports_tolerates_duplicates(self):

--- a/tests/unit/domain/test_contract.py
+++ b/tests/unit/domain/test_contract.py
@@ -19,6 +19,7 @@ class MyField(fields.Field):
 class MyContract(Contract):
     foo = MyField()
     bar = MyField(required=False)
+    baz = MyField(default="some default")
 
     def check(self, *args, **kwargs):
         raise NotImplementedError
@@ -63,6 +64,21 @@ def test_contract_validation(contract_options, expected_errors):
         assert e.errors == expected_errors
     else:
         assert False, "Did not raise InvalidContractOptions."  # pragma: nocover
+
+
+@pytest.mark.parametrize("provide_value_for_field", (True, False))
+def test_contract_populated_with_default(provide_value_for_field):
+    contract_options = {"foo": "Something for foo"}
+    if provide_value_for_field:
+        contract_options["baz"] = expected_value = "a non-default value"
+    else:
+        expected_value = "some default"
+
+    contract = MyContract(
+        name="My contract", session_options={}, contract_options=contract_options
+    )
+
+    assert contract.baz == expected_value
 
 
 class TestContractRegistry:

--- a/tests/unit/domain/test_fields.py
+++ b/tests/unit/domain/test_fields.py
@@ -1,5 +1,5 @@
 import enum
-from typing import Any, Dict, Optional, Type
+from typing import Any, Dict, List, Optional, Type, Union
 
 import pytest
 
@@ -21,6 +21,15 @@ class MyEnum(enum.Enum):
     NONE = "none"
     ONE = "one"
     TWO = "two"
+
+
+def test_field_cannot_be_instantiated_with_default_and_required():
+    class SomeField(Field):
+        def parse(self, raw_data: Union[str, List]) -> str:
+            raise NotImplementedError
+
+    with pytest.raises(ValueError, match="A required field cannot also provide a default value."):
+        SomeField(required=True, default="something")
 
 
 class BaseFieldTest:

--- a/tests/unit/domain/test_helpers.py
+++ b/tests/unit/domain/test_helpers.py
@@ -10,6 +10,8 @@ from importlinter.domain.helpers import (
     import_expressions_to_imports,
     pop_import_expressions,
     pop_imports,
+    pop_unresolved_import_expressions,
+    unresolved_import_expressions_to_imports,
 )
 from importlinter.domain.imports import DirectImport, ImportExpression, Module
 
@@ -271,6 +273,169 @@ class TestImportExpressionsToImports:
         return graph
 
 
+class TestUnresolvedImportExpressionsToImports:
+    DIRECT_IMPORTS = [
+        DirectImport(
+            importer=Module("mypackage.green"),
+            imported=Module("mypackage.yellow"),
+            line_number=1,
+            line_contents="-",
+        ),
+        DirectImport(
+            importer=Module("mypackage.green"),
+            imported=Module("mypackage.blue"),
+            line_number=1,
+            line_contents="-",
+        ),
+        DirectImport(
+            importer=Module("mypackage.blue"),
+            imported=Module("mypackage.green"),
+            line_number=1,
+            line_contents="-",
+        ),
+        DirectImport(
+            importer=Module("mypackage.blue.cats"),
+            imported=Module("mypackage.purple.dogs"),
+            line_number=1,
+            line_contents="-",
+        ),
+        DirectImport(
+            importer=Module("mypackage.green.cats"),
+            imported=Module("mypackage.orange.dogs"),
+            line_number=1,
+            line_contents="-",
+        ),
+        DirectImport(
+            importer=Module("mypackage.green.cats"),
+            imported=Module("mypackage.orange.mice"),
+            line_number=1,
+            line_contents="-",
+        ),
+        # Direct imports of external packages can appear more than once, as the external package
+        # is squashed.
+        DirectImport(
+            importer=Module("mypackage.brown"),
+            imported=Module("someotherpackage"),
+            line_number=1,
+            line_contents="from someotherpackage import one",
+        ),
+        DirectImport(
+            importer=Module("mypackage.brown"),
+            imported=Module("someotherpackage"),
+            line_number=2,
+            line_contents="from someotherpackage import two",
+        ),
+    ]
+
+    @pytest.mark.parametrize(
+        "description, expressions, expected",
+        [
+            (
+                "No wildcards",
+                [
+                    ImportExpression(
+                        importer=DIRECT_IMPORTS[0].importer.name,
+                        imported=DIRECT_IMPORTS[0].imported.name,
+                    ),
+                ],
+                [DIRECT_IMPORTS[0]],
+            ),
+            (
+                "Importer wildcard",
+                [
+                    ImportExpression(importer="mypackage.*", imported="mypackage.blue"),
+                ],
+                [DIRECT_IMPORTS[1]],
+            ),
+            (
+                "Imported wildcard",
+                [
+                    ImportExpression(importer="mypackage.green", imported="mypackage.*"),
+                ],
+                DIRECT_IMPORTS[0:2],
+            ),
+            (
+                "Importer and imported wildcards",
+                [
+                    ImportExpression(importer="mypackage.*", imported="mypackage.*"),
+                ],
+                DIRECT_IMPORTS[0:3],
+            ),
+            (
+                "Inner wildcard",
+                [
+                    ImportExpression(importer="mypackage.*.cats", imported="mypackage.*.dogs"),
+                ],
+                DIRECT_IMPORTS[3:5],
+            ),
+            (
+                "Multiple expressions, non-overlapping",
+                [
+                    ImportExpression(importer="mypackage.green", imported="mypackage.*"),
+                    ImportExpression(
+                        importer="mypackage.green.cats", imported="mypackage.orange.*"
+                    ),
+                ],
+                DIRECT_IMPORTS[0:2] + DIRECT_IMPORTS[4:6],
+            ),
+            (
+                "Multiple expressions, overlapping",
+                [
+                    ImportExpression(importer="mypackage.*", imported="mypackage.blue"),
+                    ImportExpression(importer="mypackage.green", imported="mypackage.blue"),
+                ],
+                [DIRECT_IMPORTS[1]],
+            ),
+            (
+                "Multiple imports of external package with same importer",
+                [
+                    ImportExpression(importer="mypackage.brown", imported="someotherpackage"),
+                ],
+                DIRECT_IMPORTS[6:8],
+            ),
+        ],
+    )
+    def test_succeeds(
+        self, description: str, expressions: List[ImportExpression], expected: List[DirectImport]
+    ):
+        graph = self._build_graph(self.DIRECT_IMPORTS)
+
+        actual = unresolved_import_expressions_to_imports(graph, expressions)
+        actual_resolved_imports, acautl_unresolved_imports = actual
+
+        assert acautl_unresolved_imports == []
+        assert sorted(actual_resolved_imports, key=_direct_import_sort_key) == sorted(
+            expected, key=_direct_import_sort_key
+        )
+
+    def test_returns_missing_import(self):
+        graph = ImportGraph()
+        graph.add_module("mypackage")
+        graph.add_module("other")
+        graph.add_import(
+            importer="mypackage.b", imported="other.foo", line_number=1, line_contents="-"
+        )
+
+        expression = ImportExpression(importer="mypackage.a.*", imported="other.foo")
+
+        actual = unresolved_import_expressions_to_imports(graph, [expression])
+        expected = ([], [ImportExpression(imported="other.foo", importer="mypackage.a.*")])
+
+        assert actual == expected
+
+    # fixme: make a base class
+    def _build_graph(self, direct_imports):
+        graph = ImportGraph()
+        for direct_import in direct_imports:
+            graph.add_import(
+                importer=direct_import.importer.name,
+                imported=direct_import.imported.name,
+                line_number=direct_import.line_number,
+                line_contents=direct_import.line_contents,
+            )
+        return graph
+
+
 class TestPopImportExpressions:
     DIRECT_IMPORTS = [
         DirectImport(
@@ -331,6 +496,97 @@ class TestPopImportExpressions:
             key=_direct_import_sort_key,
         )
         assert popped_direct_imports == expected
+        assert graph.count_imports() == 2
+
+    def _build_graph(self, direct_imports):
+        graph = ImportGraph()
+        for direct_import in direct_imports:
+            graph.add_import(
+                importer=direct_import.importer.name,
+                imported=direct_import.imported.name,
+                line_number=direct_import.line_number,
+                line_contents=direct_import.line_contents,
+            )
+        return graph
+
+    def _dict_to_direct_import(self, import_details: Dict[str, Union[str, int]]) -> DirectImport:
+        return DirectImport(
+            importer=Module(cast(str, import_details["importer"])),
+            imported=Module(cast(str, import_details["imported"])),
+            line_number=cast(int, import_details["line_number"]),
+            line_contents=cast(str, import_details["line_contents"]),
+        )
+
+
+class TestPopUnresolvedImportExpressions:
+    # fixme: make shared class
+    DIRECT_IMPORTS = [
+        DirectImport(
+            importer=Module("mypackage.green"),
+            imported=Module("mypackage.yellow"),
+            line_number=1,
+            line_contents="-",
+        ),
+        DirectImport(
+            importer=Module("mypackage.green"),
+            imported=Module("mypackage.blue"),
+            line_number=1,
+            line_contents="-",
+        ),
+        DirectImport(
+            importer=Module("mypackage.blue"),
+            imported=Module("mypackage.green"),
+            line_number=1,
+            line_contents="-",
+        ),
+        DirectImport(
+            importer=Module("mypackage.blue.cats"),
+            imported=Module("mypackage.purple.dogs"),
+            line_number=1,
+            line_contents="-",
+        ),
+        DirectImport(
+            importer=Module("mypackage.green.cats"),
+            imported=Module("mypackage.orange.dogs"),
+            line_number=1,
+            line_contents="-",
+        ),
+    ]
+
+    def test_succeeds(self):
+        graph = self._build_graph(self.DIRECT_IMPORTS)
+        expressions = [
+            ImportExpression(importer="mypackage.green", imported="mypackage.*"),
+            # Expressions can overlap.
+            ImportExpression(importer="mypackage.green", imported="mypackage.blue"),
+            ImportExpression(importer="mypackage.blue.cats", imported="mypackage.purple.dogs"),
+            # Missing import
+            ImportExpression(importer="mypackage.green", imported="mypackage.black.*"),
+        ]
+
+        # popped_imports: List[Dict[str, Union[str, int]]] = pop_unresolved_import_expressions(
+        popped_imports = pop_unresolved_import_expressions(graph, expressions)
+
+        popped_resolved_imports, popped_unresolved_imports = popped_imports
+
+        # Cast to direct imports to make comparison easier.
+        popped_direct_imports: List[DirectImport] = sorted(
+            map(self._dict_to_direct_import, popped_resolved_imports), key=_direct_import_sort_key
+        )
+        expected_resolved_imports = sorted(
+            [
+                self.DIRECT_IMPORTS[0],
+                self.DIRECT_IMPORTS[1],
+                self.DIRECT_IMPORTS[3],
+            ],
+            key=_direct_import_sort_key,
+        )
+        expected_unresolved_imports = [
+            ImportExpression(importer="mypackage.green", imported="mypackage.black.*")
+        ]
+
+        assert popped_direct_imports == expected_resolved_imports
+        assert popped_unresolved_imports == expected_unresolved_imports
         assert graph.count_imports() == 2
 
     def _build_graph(self, direct_imports):

--- a/tests/unit/domain/test_helpers.py
+++ b/tests/unit/domain/test_helpers.py
@@ -11,7 +11,7 @@ from importlinter.domain.helpers import (
     pop_import_expressions,
     pop_imports,
     pop_unresolved_import_expressions,
-    unresolved_import_expressions_to_imports,
+    resolve_import_expressions,
 )
 from importlinter.domain.imports import DirectImport, ImportExpression, Module
 
@@ -273,7 +273,7 @@ class TestImportExpressionsToImports:
         return graph
 
 
-class TestUnresolvedImportExpressionsToImports:
+class TestResolveImportExpressions:
     DIRECT_IMPORTS = [
         DirectImport(
             importer=Module("mypackage.green"),
@@ -400,10 +400,11 @@ class TestUnresolvedImportExpressionsToImports:
     ):
         graph = self._build_graph(self.DIRECT_IMPORTS)
 
-        actual = unresolved_import_expressions_to_imports(graph, expressions)
-        actual_resolved_imports, acautl_unresolved_imports = actual
+        actual_resolved_imports, actual_unresolved_expressions = resolve_import_expressions(
+            graph, expressions
+        )
 
-        assert acautl_unresolved_imports == []
+        assert actual_unresolved_expressions == []
         assert sorted(actual_resolved_imports, key=_direct_import_sort_key) == sorted(
             expected, key=_direct_import_sort_key
         )
@@ -418,7 +419,7 @@ class TestUnresolvedImportExpressionsToImports:
 
         expression = ImportExpression(importer="mypackage.a.*", imported="other.foo")
 
-        actual = unresolved_import_expressions_to_imports(graph, [expression])
+        actual = resolve_import_expressions(graph, [expression])
         expected = ([], [ImportExpression(imported="other.foo", importer="mypackage.a.*")])
 
         assert actual == expected


### PR DESCRIPTION
Builds on the excellent work of https://github.com/seddonym/import-linter/pull/116.

As well as some refactoring, this PR:

- Gives the rendering module responsibility for how to display warnings.
- Displays warnings in a dedicated place of the report, rather than just when they are encountered.
- Adds documentation.
- Improves the test coverage.

# Example contract

```
[importlinter]
root_package = testpackage

[importlinter:contract:one]
name=Test independence contract
type=independence
modules=
    testpackage.high.blue
    testpackage.high.green
ignore_imports=
    testpackage.utils -> testpackage.high.green
    testpackage.*.nonexistent.* -> testpackage.indirect.*
    testpackage.*.blue.* -> testpackage.indirect.*
    testpackage.nonexistent -> testpackage.high.green
unmatched_ignore_imports_alerting = warn
```

# Example output

```
=============
Import Linter
=============

---------
Contracts
---------

Analyzed 20 files, 6 dependencies.
----------------------------------

Test independence contract KEPT (2 warnings)

Contracts: 1 kept, 0 broken.

--------
Warnings
--------

Test independence contract
--------------------------

- No matches for ignored import testpackage.nonexistent -> testpackage.high.green.
- No matches for ignored import testpackage.*.beige.* -> testpackage.indirect.*.
```