### PR TITLE
Add support for new lines in contract definitions

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -8,6 +8,7 @@ Authors
 Contributors
 ============
 
+* John-Anthony Thevos - https://github.com/jthevos
 * Anthony Sottile - https://github.com/asottile
 * Łukasz Skarżyński - https://github.com/skarzi
 * Daniel Jurczak - https://github.com/danieljurczak

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,11 @@ Latest
 * Support warnings in contract checks.
 * Add unmatched_ignore_imports_alerting option for each contract.
 
+1.2.7 (2022-03-24)
+------------------
+
+* Add support for new line characters in contract definitions.
+
 1.2.6 (2021-09-24)
 ------------------
 

--- a/src/importlinter/adapters/filesystem.py
+++ b/src/importlinter/adapters/filesystem.py
@@ -12,8 +12,17 @@ class FileSystem(ports.FileSystem):
         return os.path.join(*components)
 
     def read(self, file_name: str) -> str:
+        """
+        Return all non "\n" lines as a string while preserving formatting.
+        """
+        cleaned_file_str = ""
         with open(file_name) as file:
-            return file.read()
+            for line in file.readlines():
+                if line == '\n':
+                    continue
+                else:
+                    cleaned_file_str += line
+            return cleaned_file_str
 
     def exists(self, file_name: str) -> bool:
         return os.path.isfile(file_name)


### PR DESCRIPTION
This PR adds support for new line characters in contract definitions. Without this change, any new lines would cause a malformed contract error - forcing you to add a `#` on every new line. Instead of adapting the error message to explain this limitation, it is simpler to remove the limitation. 

There is no specific test written for this change, because I _thiiink_ the existing test for `filesystem::read` covers it already. If I am mistaken about this, a specific test will be written.