### PR TITLE
Added support for extended interpolations for .ini files.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+Snapshot
+--------
+
+* Added support for extended interpolation for .ini files.
+
 1.2.7 (2022-04-04)
 ------------------
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -52,6 +52,29 @@ Or, with multiple root packages:
 
 .. _the Grimp build_graph documentation: https://grimp.readthedocs.io/en/latest/usage.html#grimp.build_graph
 
+**Interpolations**
+
+When using `.ini` file, extended interpolation may be used, which may be helpful when
+groups of modules need to be referenced in multiple places.
+
+.. code-block:: ini
+
+    [importlinter:contract:1]
+    name = Ports should not depend on adapters.
+    type = forbidden
+    source_modules = ${ports:all}
+    forbidden_modules = ${adapters:all}
+
+    [ports]
+    all =
+        mypackage.inbound
+        yourpackage.outbound
+
+    [adapters]
+    all =
+        mypackage.adapters
+        yourpackage.adapters
+
 Contracts
 ---------
 

--- a/src/importlinter/adapters/user_options.py
+++ b/src/importlinter/adapters/user_options.py
@@ -51,7 +51,9 @@ class IniFileUserOptionReader(AbstractUserOptionReader):
     section_name = "importlinter"
 
     def _read_config_filename(self, config_filename: str) -> Optional[UserOptions]:
-        config = configparser.ConfigParser()
+        config = configparser.ConfigParser(
+            interpolation=configparser.ExtendedInterpolation(),
+        )
         file_contents = settings.FILE_SYSTEM.read(config_filename)
         config.read_string(file_contents)
         if self.section_name in config.sections():

--- a/tests/assets/testpackage/.interpolationcontract.ini
+++ b/tests/assets/testpackage/.interpolationcontract.ini
@@ -1,0 +1,15 @@
+[importlinter]
+root_package = testpackage
+include_external_packages = True
+
+[importlinter:contract:one]
+name=Expected kept contract
+type=forbidden
+source_modules=
+    ${section_to_interpolate:source}
+forbidden_modules=
+    sqlalchemy
+
+[section_to_interpolate]
+source=
+    testpackage.high.green

--- a/tests/functional/test_lint_imports.py
+++ b/tests/functional/test_lint_imports.py
@@ -18,6 +18,7 @@ unmatched_ignore_imports_directory = testpackage_directory / "unmatched_ignore_i
     (
         (testpackage_directory, None, cli.EXIT_STATUS_SUCCESS),
         (testpackage_directory, ".brokencontract.ini", cli.EXIT_STATUS_ERROR),
+        (testpackage_directory, ".interpolationcontract.ini", cli.EXIT_STATUS_SUCCESS),
         (testpackage_directory, ".malformedcontract.ini", cli.EXIT_STATUS_ERROR),
         (testpackage_directory, ".customkeptcontract.ini", cli.EXIT_STATUS_SUCCESS),
         (testpackage_directory, ".externalbrokencontract.ini", cli.EXIT_STATUS_ERROR),


### PR DESCRIPTION
I had a use case consisting of a rather complicated project with a lot of legacy code that we are trying to organize. Both the `layers` and `independence` contracts would have to have more `ignores` that would be practical. It seemed to be easier to define groups of modules explicitly (or ideally with wild cards) and enforce architecture that way.

This PR configures `.ini` files to use the `configparser.ExtendedInterpolation()`. Unfortunately, I don't think `toml` has built in support for interpolations, and I'm not really sure how each package manager will set up the ini parser when parsing `setup.cfg`, so I had no reliable way add the feature when handling those formats.

Tests pass

```
nickswebsite(.venv)$ tox

...

report run-test: commands[1] | coverage html
Wrote HTML report to htmlcov/index.html
_____________________________________________________________________________________________________________________ summary _____________________________________________________________________________________________________________________
  clean: commands succeeded
  check: commands succeeded
  docs: commands succeeded
  py37-notoml: commands succeeded
  py37-toml: commands succeeded
  py38-notoml: commands succeeded
  py38-toml: commands succeeded
  py39-notoml: commands succeeded
  py39-toml: commands succeeded
  py310-notoml: commands succeeded
  py310-toml: commands succeeded
  report: commands succeeded
  congratulations :)
```

Docs Build
![Import-Linter-Docs-Screenshot](https://user-images.githubusercontent.com/7522772/163595016-d67b5889-877c-4dcb-bf52-d9e0d94e0668.png)
