### PR TITLE
Include `py.typed` in package data

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -15,3 +15,4 @@ Contributors
 * Aaron Gokaslan - https://github.com/Skylion007
 * Kai Mueller - https://github.com/kasium
 * Daniele Esposti - https://github.com/expobrain
+* Petter Friberg - https://github.com/flaeppe

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+latest
+------
+
+* Include py.typed file in package data to support type checking
+
 1.3.0 (2022-08-22)
 ------------------
 

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup(
         "Source code": "https://github.com/seddonym/import-linter/",
     },
     packages=find_packages("src"),
+    package_data={"importlinter": ["py.typed"]},
     package_dir={"": "src"},
     py_modules=[splitext(basename(path))[0] for path in glob("src/*.py")],
     include_package_data=True,


### PR DESCRIPTION
Marks package to support type checking

Fixes: #128 