### PR TITLE
Two pass layers

### DIFF
--- a/src/importlinter/domain/ports/graph.py
+++ b/src/importlinter/domain/ports/graph.py
@@ -18,6 +18,9 @@ class ImportGraph(Protocol):
         """
         raise NotImplementedError
 
+    def find_children(self, module: str) -> Set[str]:
+        raise NotImplementedError
+
     def find_descendants(self, module: str) -> Set[str]:
         raise NotImplementedError
 
@@ -73,6 +76,9 @@ class ImportGraph(Protocol):
         raise NotImplementedError
 
     def squash_module(self, module: str) -> None:
+        raise NotImplementedError
+
+    def is_module_squashed(self, module: str) -> bool:
         raise NotImplementedError
 
     def remove_module(self, module: str) -> None:

--- a/src/importlinter/domain/ports/graph.py
+++ b/src/importlinter/domain/ports/graph.py
@@ -65,3 +65,15 @@ class ImportGraph(Protocol):
 
     def remove_import(self, *, importer: str, imported: str) -> None:
         raise NotImplementedError
+
+    def find_modules_directly_imported_by(self, module: str) -> Set[str]:
+        raise NotImplementedError
+
+    def find_modules_that_directly_import(self, module: str) -> Set[str]:
+        raise NotImplementedError
+
+    def squash_module(self, module: str) -> None:
+        raise NotImplementedError
+
+    def remove_module(self, module: str) -> None:
+        raise NotImplementedError

--- a/tests/unit/contracts/test_layers.py
+++ b/tests/unit/contracts/test_layers.py
@@ -1608,3 +1608,70 @@ class TestPopDirectImports:
             assert graph.direct_import_exists(
                 importer=other_import["importer"], imported=other_import["imported"]
             )
+
+
+class TestRecursivelySquashNonDirectAncestors:
+    def test_top_level_module(self):
+        graph = self._build_graph()
+        graph.squash_module("mypackage")
+
+        LayersContract._recursively_squash_non_direct_ancestors(graph, Module("mypackage"))
+
+        assert graph.modules == {"mypackage", "another", "yetanother"}
+
+    def test_second_level_module(self):
+        graph = self._build_graph()
+        graph.squash_module("mypackage.green")
+
+        LayersContract._recursively_squash_non_direct_ancestors(graph, Module("mypackage.green"))
+
+        assert graph.modules == {
+            "mypackage",
+            "mypackage.green",
+            "mypackage.blue",
+            "mypackage.orange",
+            "another",
+            "yetanother",
+        }
+
+    def test_third_level_module(self):
+        graph = self._build_graph()
+
+        LayersContract._recursively_squash_non_direct_ancestors(
+            graph, Module("mypackage.green.two")
+        )
+
+        assert graph.modules == {
+            "mypackage",
+            "mypackage.green",
+            "mypackage.green.one",
+            "mypackage.green.two",
+            "mypackage.green.three",
+            "mypackage.blue",
+            "mypackage.orange",
+            "another",
+            "yetanother",
+        }
+
+    def _build_graph(self):
+        graph = ImportGraph()
+        graph.add_module("mypackage")
+        graph.add_module("mypackage.green")
+        graph.add_module("mypackage.green.one")
+        graph.add_module("mypackage.green.one.alpha")
+        graph.add_module("mypackage.green.one.beta")
+        graph.add_module("mypackage.green.one.gamma")
+        graph.add_module("mypackage.green.two")
+        graph.add_module("mypackage.green.three")
+        graph.add_module("mypackage.blue")
+        graph.add_module("mypackage.blue.one")
+        graph.add_module("mypackage.blue.two")
+        graph.add_module("mypackage.blue.three")
+        graph.add_module("mypackage.orange")
+        graph.add_module("another")
+        graph.add_module("another.blue")
+        graph.add_module("another.blue.one")
+        graph.add_module("yetanother")
+        graph.add_module("yetanother.orange")
+        graph.add_module("yetanother.orange.two")
+        return graph

--- a/tests/unit/contracts/test_layers.py
+++ b/tests/unit/contracts/test_layers.py
@@ -107,6 +107,22 @@ class TestLayerMultipleContainers:
 
         assert contract_check.kept is False
 
+    def test_import_via_noncontainer_means_contract_is_broken(self):
+        contract = self._build_contract()
+        graph = self._build_graph()
+        graph.add_import(
+            importer="mypackage.one.medium.orange", imported="mypackage.noncontainer.blue"
+        )
+        graph.add_import(
+            importer="mypackage.noncontainer.blue", imported="mypackage.two.high.red.alpha"
+        )
+        graph.add_import(
+            importer="mypackage.two.high.red.alpha", imported="mypackage.one.high.green"
+        )
+        contract_check = contract.check(graph=graph)
+
+        assert contract_check.kept is False
+
     def _build_graph(self):
         graph = ImportGraph()
         for module in (
@@ -142,6 +158,8 @@ class TestLayerMultipleContainers:
             "mypackage.three.medium.purple",
             "mypackage.three.low",
             "mypackage.three.low.cyan",
+            "mypackage.noncontainer",
+            "mypackage.noncontainer.blue",
         ):
             graph.add_module(module)
 


### PR DESCRIPTION
Currently, checking layers for containers deep in the module hierarchy take a long time. I think this is because the current optimisations, which squash the layers under test, work best for shallower modules. For deep modules, there will be a lot of modules that are unsquashed and the shortest paths need to be checked repeatedly.

This PR experiments with a two-pass approach in which all the other non-ancestor modules are squashed in a first pass and then we see if there is at least one import between layers. In theory this would optimise for passing contracts, though it will be slower for failing contracts as it will then need to check the graph again to get the actual imports.

Unfortunately in its current form it is about twice as slow for the deep modules I sampled. I still think there is potential with this approach but it needs more thought. Profiling the code is probably the next step to understand what is taking a long time.