### PR TITLE
Lift upper bounds on Grimp

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,8 @@ latest
 ------
 
 * Include py.typed file in package data to support type checking
+* Remove upper bounds on dependencies. This allows usage of Grimp 2.0, which should significantly speed up checking of
+  layers contracts.
 
 1.3.0 (2022-08-22)
 ------------------

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
         "Topic :: Utilities",
     ],
     python_requires=">=3.7",
-    install_requires=["click>=6,<9", "grimp>=1.3,<2", "typing-extensions>=3.10.0.0"],
+    install_requires=["click>=6", "grimp>=1.3", "typing-extensions>=3.10.0.0"],
     extras_require={"toml": ["toml"]},
     entry_points={
         "console_scripts": ["lint-imports = importlinter.cli:lint_imports_command"]


### PR DESCRIPTION
Lifts upper bounds, supporting Grimp 2.0 which is much faster for layers contracts with large number of layers.