### PR TITLE
Improvements to support type-hinting

### DIFF
--- a/src/importlinter/__init__.py
+++ b/src/importlinter/__init__.py
@@ -3,3 +3,7 @@ __version__ = "1.6.0"
 from .application import output  # noqa
 from .domain import fields  # noqa
 from .domain.contract import Contract, ContractCheck  # noqa
+from importlinter.domain.ports.graph import ImportGraph  # noqa
+
+
+__all__ = ["output", "fields", "Contract", "ContractCheck", "ImportGraph"]

--- a/src/importlinter/application/output.py
+++ b/src/importlinter/application/output.py
@@ -46,13 +46,13 @@ class Output:
         """
         self.printer.print(text, bold, color, newline)
 
-    def indent_cursor(self):
+    def indent_cursor(self) -> None:
         """
         Indents the cursor ready to print a line.
         """
         self.printer.print(" " * INDENT_SIZE, newline=False)
 
-    def new_line(self):
+    def new_line(self) -> None:
         """
         Print a blank line.
         """
@@ -84,19 +84,19 @@ class Output:
         self.printer.print(heading_line, bold=is_bold, color=color)
         self.printer.print()
 
-    def print_success(self, text, bold=True):
+    def print_success(self, text: str, bold: bool = True) -> None:
         """
         Prints a line to the console, formatted as a success.
         """
         self.printer.print(text, color=COLORS[SUCCESS], bold=bold)
 
-    def print_error(self, text, bold=True):
+    def print_error(self, text: str, bold: bool = True) -> None:
         """
         Prints a line to the console, formatted as an error.
         """
         self.printer.print(text, color=COLORS[ERROR], bold=bold)
 
-    def print_warning(self, text):
+    def print_warning(self, text: str) -> None:
         """
         Prints a line to the console, formatted as a warning.
         """


### PR DESCRIPTION
When attempting to use the output functions in plugins, mypy was warning about calling untyped functions. The changes to output.py should resolve this.

It's also necessary to import the ImportGraph protocol when creating a plugin, so it makes sense that this should be exported at the top level too. This avoids needing to reach deep into the package.