### PR TITLE
Use new and better DetailedImport type from grimp

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
     python_requires=">=3.7",
     install_requires=[
         "click>=6",
-        "grimp>=2.0",
+        "grimp>=2.2",
         "tomli>=1.2.1; python_version < '3.11'",
         "typing-extensions>=3.10.0.0",
     ],

--- a/src/importlinter/adapters/building.py
+++ b/src/importlinter/adapters/building.py
@@ -1,6 +1,6 @@
 from typing import List
 
-import grimp  # type: ignore
+import grimp
 from importlinter.application.ports import building as ports
 from importlinter.domain.ports.graph import ImportGraph
 

--- a/src/importlinter/contracts/layers.py
+++ b/src/importlinter/contracts/layers.py
@@ -392,7 +392,7 @@ class LayersContract(Contract):
                             {
                                 "importer": lower_layer_module,
                                 "imported": imported_module,
-                                "line_number": "?",
+                                "line_number": -1,
                                 "line_contents": "",
                             }
                         ]

--- a/src/importlinter/domain/helpers.py
+++ b/src/importlinter/domain/helpers.py
@@ -1,6 +1,8 @@
 import itertools
 import re
-from typing import Dict, Iterable, List, Pattern, Set, Tuple, Union, cast
+from typing import Iterable, List, Pattern, Set, Tuple, cast
+
+from grimp import DetailedImport
 
 from importlinter.domain.imports import DirectImport, ImportExpression, Module
 from importlinter.domain.ports.graph import ImportGraph
@@ -10,9 +12,7 @@ class MissingImport(Exception):
     pass
 
 
-def pop_imports(
-    graph: ImportGraph, imports: Iterable[DirectImport]
-) -> List[Dict[str, Union[str, int]]]:
+def pop_imports(graph: ImportGraph, imports: Iterable[DirectImport]) -> List[DetailedImport]:
     """
     Removes the supplied direct imports from the graph.
 
@@ -22,7 +22,7 @@ def pop_imports(
     Raises:
         MissingImport if an import is not present in the graph.
     """
-    removed_imports: List[Dict[str, Union[str, int]]] = []
+    removed_imports: List[DetailedImport] = []
 
     imports_to_remove = _dedupe_imports(imports)
 
@@ -121,7 +121,7 @@ def resolve_import_expressions(
 
 def pop_import_expressions(
     graph: ImportGraph, expressions: Iterable[ImportExpression]
-) -> List[Dict[str, Union[str, int]]]:
+) -> List[DetailedImport]:
     """
     Removes any imports matching the supplied import expressions from the graph.
 
@@ -135,7 +135,7 @@ def pop_import_expressions(
     return pop_imports(graph, imports)
 
 
-def add_imports(graph: ImportGraph, import_details: List[Dict[str, Union[str, int]]]) -> None:
+def add_imports(graph: ImportGraph, import_details: List[DetailedImport]) -> None:
     """
     Adds the supplied import details to the graph.
 

--- a/src/importlinter/domain/ports/graph.py
+++ b/src/importlinter/domain/ports/graph.py
@@ -1,7 +1,9 @@
-from typing import Dict, List, Optional, Set, Tuple, Union
+from typing import List, Optional, Set, Tuple
 
 # N.B. typing_extensions can be changed to typing once drop support for Python 3.7.
 from typing_extensions import Protocol
+
+from grimp import DetailedImport
 
 
 class ImportGraph(Protocol):
@@ -39,9 +41,7 @@ class ImportGraph(Protocol):
         """
         raise NotImplementedError
 
-    def get_import_details(
-        self, *, importer: str, imported: str
-    ) -> List[Dict[str, Union[str, int]]]:
+    def get_import_details(self, *, importer: str, imported: str) -> List[DetailedImport]:
         """
         Returns a list of the details of every direct import between two modules, in the form:
         [

--- a/tests/unit/application/test_contract_utils.py
+++ b/tests/unit/application/test_contract_utils.py
@@ -1,5 +1,5 @@
 import pytest
-from grimp.adaptors.graph import ImportGraph  # type: ignore
+from grimp.adaptors.graph import ImportGraph
 
 from importlinter.application.contract_utils import AlertLevel, remove_ignored_imports
 from importlinter.domain.helpers import MissingImport

--- a/tests/unit/application/test_use_cases.py
+++ b/tests/unit/application/test_use_cases.py
@@ -2,7 +2,7 @@ import string
 from typing import Any, Dict, List, Optional
 
 import pytest
-from grimp.adaptors.graph import ImportGraph  # type: ignore
+from grimp.adaptors.graph import ImportGraph
 
 from importlinter.application.app_config import settings
 from importlinter.application.use_cases import FAILURE, SUCCESS, create_report, lint_imports

--- a/tests/unit/contracts/test_forbidden.py
+++ b/tests/unit/contracts/test_forbidden.py
@@ -1,5 +1,5 @@
 import pytest
-from grimp.adaptors.graph import ImportGraph  # type: ignore
+from grimp.adaptors.graph import ImportGraph
 
 from importlinter.configuration import settings
 from importlinter.contracts.forbidden import ForbiddenContract

--- a/tests/unit/contracts/test_independence.py
+++ b/tests/unit/contracts/test_independence.py
@@ -1,5 +1,5 @@
 import pytest
-from grimp.adaptors.graph import ImportGraph  # type: ignore
+from grimp.adaptors.graph import ImportGraph
 
 from importlinter.application.app_config import settings
 from importlinter.contracts.independence import IndependenceContract

--- a/tests/unit/contracts/test_layers.py
+++ b/tests/unit/contracts/test_layers.py
@@ -1,5 +1,5 @@
 import pytest
-from grimp.adaptors.graph import ImportGraph  # type: ignore
+from grimp.adaptors.graph import ImportGraph
 
 from importlinter.application.app_config import settings
 from importlinter.contracts.layers import LayersContract

--- a/tests/unit/domain/test_helpers.py
+++ b/tests/unit/domain/test_helpers.py
@@ -1,7 +1,8 @@
 import re
-from typing import Dict, List, Union, cast
+from typing import List
 
 import pytest
+from grimp import DetailedImport
 from grimp.adaptors.graph import ImportGraph  # type: ignore
 
 from importlinter.domain.helpers import (
@@ -16,7 +17,7 @@ from importlinter.domain.imports import DirectImport, ImportExpression, Module
 
 
 class TestPopImports:
-    IMPORTS = [
+    IMPORTS: List[DetailedImport] = [
         dict(
             importer="mypackage.green",
             imported="mypackage.yellow",
@@ -74,7 +75,7 @@ class TestPopImports:
             pop_imports(graph, [non_existent_import])
 
     def test_works_with_multiple_external_imports_from_same_module(self):
-        imports_to_pop = [
+        imports_to_pop: List[DetailedImport] = [
             dict(
                 importer="mypackage.green",
                 imported="someexternalpackage",
@@ -478,9 +479,7 @@ class TestPopImportExpressions:
             ImportExpression(importer="mypackage.blue.cats", imported="mypackage.purple.dogs"),
         ]
 
-        popped_imports: List[Dict[str, Union[str, int]]] = pop_import_expressions(
-            graph, expressions
-        )
+        popped_imports: List[DetailedImport] = pop_import_expressions(graph, expressions)
 
         # Cast to direct imports to make comparison easier.
         popped_direct_imports: List[DirectImport] = sorted(
@@ -508,18 +507,18 @@ class TestPopImportExpressions:
             )
         return graph
 
-    def _dict_to_direct_import(self, import_details: Dict[str, Union[str, int]]) -> DirectImport:
+    def _dict_to_direct_import(self, import_details: DetailedImport) -> DirectImport:
         return DirectImport(
-            importer=Module(cast(str, import_details["importer"])),
-            imported=Module(cast(str, import_details["imported"])),
-            line_number=cast(int, import_details["line_number"]),
-            line_contents=cast(str, import_details["line_contents"]),
+            importer=Module(import_details["importer"]),
+            imported=Module(import_details["imported"]),
+            line_number=import_details["line_number"],
+            line_contents=import_details["line_contents"],
         )
 
 
 def test_add_imports():
     graph = ImportGraph()
-    import_details = [
+    import_details: List[DetailedImport] = [
         {"importer": "a", "imported": "b", "line_number": 1, "line_contents": "lorem ipsum"},
         {"importer": "c", "imported": "d", "line_number": 2, "line_contents": "lorem ipsum 2"},
     ]

--- a/tests/unit/domain/test_helpers.py
+++ b/tests/unit/domain/test_helpers.py
@@ -3,7 +3,7 @@ from typing import List
 
 import pytest
 from grimp import DetailedImport
-from grimp.adaptors.graph import ImportGraph  # type: ignore
+from grimp.adaptors.graph import ImportGraph
 
 from importlinter.domain.helpers import (
     MissingImport,


### PR DESCRIPTION
This provides much more accurate type information about imports. This helps not just this codebase but all plugins too.

I had to replace one string containing a question mark with a -1, as strings are now correctly no longer accepted as line numbers.