### PR TITLE
Don't display covered files in coverage report

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -12,6 +12,7 @@ parallel = true
 
 [report]
 show_missing = true
+skip_covered = true
 precision = 2
 omit = *migrations*
 exclude_lines =


### PR DESCRIPTION
While fiddling with #162, it felt a bit cluttered to have coverage display 100% covered files