### PR TITLE
Enable `warn_redundant_casts` for mypy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,3 +12,5 @@ line_length = 99
 exclude = [
     '^tests/assets/',
 ]
+warn_unused_ignores = true
+warn_redundant_casts = true

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,10 +2,3 @@
 ignore = E731, E203, W503
 max-line-length = 100
 exclude = */migrations/*, tests/assets/*
-
-[mypy]
-warn_unused_ignores = True
-
-[mypy-pytest]
-ignore_missing_imports = True
-

--- a/src/importlinter/application/contract_utils.py
+++ b/src/importlinter/application/contract_utils.py
@@ -38,7 +38,7 @@ def remove_ignored_imports(
 
     warnings = _handle_unresolved_import_expressions(
         unresolved_expressions,
-        unmatched_alerting,  # type: ignore
+        unmatched_alerting,
     )
 
     helpers.pop_imports(graph, imports)

--- a/src/importlinter/contracts/_common.py
+++ b/src/importlinter/contracts/_common.py
@@ -6,7 +6,7 @@ relying on it for a custom contract type, be aware things may change
 without warning.
 """
 
-from typing import List, Optional, Sequence, Tuple, Union, cast
+from typing import List, Optional, Sequence, Tuple, Union
 
 from typing_extensions import TypedDict
 
@@ -62,7 +62,7 @@ def find_segments(
             import_details = reference_graph.get_import_details(
                 importer=importer_in_chain, imported=imported_in_chain
             )
-            line_numbers = tuple(sorted(set(cast(int, j["line_number"]) for j in import_details)))
+            line_numbers = tuple(sorted(set(j["line_number"] for j in import_details)))
             segment.append(
                 {
                     "importer": importer_in_chain,
@@ -90,9 +90,7 @@ def segments_to_collapsed_chains(
             import_details_list = graph.get_import_details(
                 importer=module, imported=imported_module
             )
-            line_numbers = tuple(
-                sorted(set(cast(int, j["line_number"]) for j in import_details_list))
-            )
+            line_numbers = tuple(sorted(set(j["line_number"] for j in import_details_list)))
             head_imports.append(
                 {"importer": module, "imported": imported_module, "line_numbers": line_numbers}
             )
@@ -108,9 +106,7 @@ def segments_to_collapsed_chains(
             import_details_list = graph.get_import_details(
                 importer=importer_module, imported=module
             )
-            line_numbers = tuple(
-                sorted(set(cast(int, j["line_number"]) for j in import_details_list))
-            )
+            line_numbers = tuple(sorted(set(j["line_number"] for j in import_details_list)))
             tail_imports.append(
                 {"importer": importer_module, "imported": module, "line_numbers": line_numbers}
             )

--- a/src/importlinter/contracts/independence.py
+++ b/src/importlinter/contracts/independence.py
@@ -65,7 +65,7 @@ class IndependenceContract(Contract):
 
         temp_graph = copy.deepcopy(graph)
         # First pass: direct imports.
-        for subpackage_1, subpackage_2 in permutations(modules, r=2):  # type: ignore
+        for subpackage_1, subpackage_2 in permutations(modules, r=2):
             output.verbose_print(
                 verbose,
                 "Searching for direct imports from " f"{subpackage_1} to {subpackage_2}...",
@@ -94,7 +94,7 @@ class IndependenceContract(Contract):
 
         # Second pass: indirect imports.
         self._squash_modules(graph=temp_graph, modules_to_squash=modules)
-        for subpackage_1, subpackage_2 in permutations(modules, r=2):  # type: ignore
+        for subpackage_1, subpackage_2 in permutations(modules, r=2):
             output.verbose_print(
                 verbose,
                 "Searching for indirect imports from " f"{subpackage_1} to {subpackage_2}...",
@@ -210,13 +210,13 @@ class IndependenceContract(Contract):
                     importer=importer_module, imported=imported_module
                 )
                 if import_details:
-                    line_numbers = tuple(cast(int, i["line_number"]) for i in import_details)
+                    line_numbers = tuple(i["line_number"] for i in import_details)
                     direct_imports.append(
                         {
                             "chain": [
                                 {
-                                    "importer": cast(str, import_details[0]["importer"]),
-                                    "imported": cast(str, import_details[0]["imported"]),
+                                    "importer": import_details[0]["importer"],
+                                    "imported": import_details[0]["imported"],
                                     "line_numbers": line_numbers,
                                 }
                             ],
@@ -250,7 +250,7 @@ class IndependenceContract(Contract):
                     (chain[i], chain[i + 1]) for i in range(len(chain) - 1)
                 ]:
                     import_details = graph.get_import_details(importer=importer, imported=imported)
-                    line_numbers = tuple(cast(int, j["line_number"]) for j in import_details)
+                    line_numbers = tuple(j["line_number"] for j in import_details)
                     chain_data.append(
                         {
                             "importer": importer,

--- a/src/importlinter/domain/helpers.py
+++ b/src/importlinter/domain/helpers.py
@@ -1,6 +1,6 @@
 import itertools
 import re
-from typing import Iterable, List, Pattern, Set, Tuple, cast
+from typing import Iterable, List, Pattern, Set, Tuple
 
 from grimp import DetailedImport
 
@@ -62,10 +62,10 @@ def import_expression_to_imports(
             for individual_import_details in import_details:
                 imports.add(
                     DirectImport(
-                        importer=Module(cast(str, individual_import_details["importer"])),
-                        imported=Module(cast(str, individual_import_details["imported"])),
-                        line_number=cast(int, individual_import_details["line_number"]),
-                        line_contents=cast(str, individual_import_details["line_contents"]),
+                        importer=Module(individual_import_details["importer"]),
+                        imported=Module(individual_import_details["imported"]),
+                        line_number=individual_import_details["line_number"],
+                        line_contents=individual_import_details["line_contents"],
                     )
                 )
             matched = True

--- a/tests/adapters/building.py
+++ b/tests/adapters/building.py
@@ -1,6 +1,6 @@
 from typing import List, Optional
 
-from grimp.adaptors.graph import ImportGraph as GrimpImportGraph  # type: ignore
+from grimp.adaptors.graph import ImportGraph as GrimpImportGraph
 
 from importlinter.application.ports.building import GraphBuilder
 from importlinter.domain.ports.graph import ImportGraph

--- a/tests/unit/application/test_use_cases.py
+++ b/tests/unit/application/test_use_cases.py
@@ -502,7 +502,7 @@ class TestCheckContractsAndPrintReport:
                 "forbidden: tests.helpers.contracts.ForbiddenImportContract",
                 "noisy: tests.helpers.contracts.NoisyContract",
             ]
-        session_options["contract_types"] = contract_types  # type: ignore
+        session_options["contract_types"] = contract_types
 
         reader = FakeUserOptionReader(
             UserOptions(session_options=session_options, contracts_options=contracts_options)

--- a/tests/unit/domain/test_helpers.py
+++ b/tests/unit/domain/test_helpers.py
@@ -1,5 +1,5 @@
 import re
-from typing import List
+from typing import List, Tuple, Optional
 
 import pytest
 from grimp import DetailedImport
@@ -38,7 +38,7 @@ class TestPopImports:
         ),
     ]
 
-    def test_succeeds(self):
+    def test_succeeds(self) -> None:
         graph = self._build_graph(imports=self.IMPORTS)
         imports_to_pop = self.IMPORTS[0:2]
         import_to_leave = self.IMPORTS[2]
@@ -57,7 +57,7 @@ class TestPopImports:
         )
         assert graph.count_imports() == 1
 
-    def test_raises_missing_import_if_module_not_found(self):
+    def test_raises_missing_import_if_module_not_found(self) -> None:
         graph = self._build_graph(imports=self.IMPORTS)
         non_existent_import = DirectImport(
             importer=Module("mypackage.nonexistent"),
@@ -74,7 +74,7 @@ class TestPopImports:
         ):
             pop_imports(graph, [non_existent_import])
 
-    def test_works_with_multiple_external_imports_from_same_module(self):
+    def test_works_with_multiple_external_imports_from_same_module(self) -> None:
         imports_to_pop: List[DetailedImport] = [
             dict(
                 importer="mypackage.green",
@@ -470,7 +470,7 @@ class TestPopImportExpressions:
         ),
     ]
 
-    def test_succeeds(self):
+    def test_succeeds(self) -> None:
         graph = self._build_graph(self.DIRECT_IMPORTS)
         expressions = [
             ImportExpression(importer="mypackage.green", imported="mypackage.*"),
@@ -516,7 +516,7 @@ class TestPopImportExpressions:
         )
 
 
-def test_add_imports():
+def test_add_imports() -> None:
     graph = ImportGraph()
     import_details: List[DetailedImport] = [
         {"importer": "a", "imported": "b", "line_number": 1, "line_contents": "lorem ipsum"},
@@ -527,7 +527,7 @@ def test_add_imports():
     assert graph.modules == {"a", "b", "c", "d"}
 
 
-def _direct_import_sort_key(direct_import: DirectImport):
+def _direct_import_sort_key(direct_import: DirectImport) -> Tuple[str, str, Optional[int]]:
     # Doesn't matter how we sort, just a way of sorting consistently for comparison.
     return (
         direct_import.importer.name,


### PR DESCRIPTION
I hope you think updating some type annotations is fine? As I thought it could be cool to get mypy to pass running in strict mode (`mypy --strict`)

What I tried to do here was to not do everything at once, but start out with enabling `warn_redundant_casts` and fix some of those issues.

I also saw that the `pyproject.toml` config for mypy took precedence over `setup.cfg`. So I tried to get a single config file going.

Additionally, for some reason `mypy` yielded a couple of info lines regarding `tests/unit/domain/test_helpers.py`. That's why those changes were included here.