### PR TITLE
Improve module validation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,8 @@ latest
 ------
 
 * Update to Grimp 2.4.
+* Forbidden contracts: when include_external_packages is true, error if an external subpackage is
+  a forbidden module.
 
 1.8.0 (2023-03-03)
 ------------------

--- a/tests/unit/contracts/test_forbidden.py
+++ b/tests/unit/contracts/test_forbidden.py
@@ -8,6 +8,11 @@ from tests.adapters.printing import FakePrinter
 from tests.adapters.timing import FakeTimer
 
 
+@pytest.fixture(scope="module", autouse=True)
+def configure():
+    settings.configure(TIMER=FakeTimer())
+
+
 class TestForbiddenContract:
     def test_is_kept_when_no_forbidden_modules_imported(self):
         graph = self._build_graph()


### PR DESCRIPTION
Suggested in https://github.com/seddonym/import-linter/issues/111.

The following contract has a nonobvious problem with it:

```
[importlinter]
root_package = mypackage
include_external_packages = true

[importlinter:contract:a]
name=Some contract
type=forbidden
source_modules=
    mypackage.foo
forbidden_modules=
    requests.api
```

The forbidden module `requests.api` should read just `requests`, because `requests` is not one of the root packages so, assuming mypackage imports it somewhere, it will only appear in the graph as `requests`.

Prior to this commit, if `mypackage.foo` imported `requests.api` then this contract would pass. Now, Import Linter will error, saying "Invalid forbidden module requests.api: subpackages of external packages are not valid."