### PR TITLE
Configure tox to run in isolated_build

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,5 @@
 [tox]
+isolated_build = True
 envlist =
     clean,
     check,


### PR DESCRIPTION
Prior to this, tox wouldn't run because of the existence of the pyproject.toml file.