### PR TITLE
Drop support for Python 3.7

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v3

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,10 +1,11 @@
 Changelog
 =========
 
-1.10.0 (Unreleased)
--------------------
+latest
+------
 
 * Recursive wildcard support for ignored imports.
+* Drop support for Python 3.7.
 
 1.9.0 (2023-05-13)
 ------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ description = "Enforces rules for the imports within and between Python packages
 authors = [
     {name = "David Seddon", email = "david@seddonym.me"},
 ]
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 dependencies = [
     "click>=6",
     "grimp>=2.4",
@@ -25,7 +25,6 @@ classifiers = [
     "Operating System :: POSIX",
     "Operating System :: Microsoft :: Windows",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",

--- a/src/importlinter/domain/ports/graph.py
+++ b/src/importlinter/domain/ports/graph.py
@@ -1,7 +1,4 @@
-from typing import List, Optional, Set, Tuple
-
-# N.B. typing_extensions can be changed to typing once drop support for Python 3.7.
-from typing_extensions import Protocol
+from typing import List, Optional, Protocol, Set, Tuple
 
 from grimp import DetailedImport
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,12 +4,11 @@ envlist =
     clean,
     check,
     docs,
-    py37,py38,py39,py310,py311
+    py38,py39,py310,py311
     report
 
 [testenv]
 basepython =
-    py37: {env:TOXPYTHON:python3.7}
     py38: {env:TOXPYTHON:python3.8}
     py39: {env:TOXPYTHON:python3.9}
     py310: {env:TOXPYTHON:python3.10}
@@ -64,7 +63,6 @@ deps = coverage
 [gh-actions]
 # Run check on both Python 3.10 and 3.11, because of our version-dependent dependency on tomli.
 python =
-    3.7: py37, report
     3.8: py38, report
     3.9: py39, report
     3.10: py310, report, check


### PR DESCRIPTION
As it is now end of life.