### PR TITLE
Use Grimp.find_illegal_dependencies_for_layers

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ latest
 * Recursive wildcard support for ignored imports.
 * Drop support for Python 3.7.
 * Use grimp.ImportGraph instead of importlinter.domain.ports.graph.ImportGraph.
+* Use grimp's find_illegal_dependencies_for_layers method in layers contracts.
 
 1.9.0 (2023-05-13)
 ------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,8 +13,7 @@ authors = [
 requires-python = ">=3.8"
 dependencies = [
     "click>=6",
-     # Temporarily use master branch of Grimp.
-    "grimp@git+https://github.com/seddonym/grimp",
+    "grimp>=2.5",
     "tomli>=1.2.1; python_version < '3.11'",
     "typing-extensions>=3.10.0.0",
 ]

--- a/src/importlinter/cli.py
+++ b/src/importlinter/cli.py
@@ -1,5 +1,6 @@
 import os
 import sys
+from logging import config as logging_config
 from typing import Optional, Tuple, Type, Union
 
 import click
@@ -91,6 +92,8 @@ def lint_imports(
     # Add current directory to the path, as this doesn't happen automatically.
     sys.path.insert(0, os.getcwd())
 
+    _configure_logging(verbose)
+
     combined_cache_dir = _combine_caching_arguments(cache_dir, no_cache)
 
     passed = use_cases.lint_imports(
@@ -116,3 +119,26 @@ def _combine_caching_arguments(
     if cache_dir is None:
         return NotSupplied
     return cache_dir
+
+
+def _configure_logging(verbose: bool) -> None:
+    logger_names = ("importlinter", "grimp")
+    logging_config.dictConfig(
+        {
+            "version": 1,
+            "handlers": {
+                "console": {
+                    "class": "logging.StreamHandler",
+                    "level": "INFO" if verbose else "WARNING",
+                    "stream": "ext://sys.stdout",
+                },
+            },
+            "loggers": {
+                logger_name: {
+                    "level": "INFO",
+                    "handlers": ["console"],
+                }
+                for logger_name in logger_names
+            },
+        }
+    )

--- a/tests/functional/test_lint_imports.py
+++ b/tests/functional/test_lint_imports.py
@@ -87,3 +87,15 @@ def test_lint_imports_debug_mode(is_debug_mode):
 def test_show_timings_smoke_test():
     os.chdir(testpackage_directory)
     assert cli.EXIT_STATUS_SUCCESS == cli.lint_imports(show_timings=True)
+
+
+@pytest.mark.parametrize("verbose", (True, False))
+def test_logging_configuration_respects_verbose_flag(verbose, capsys):
+    os.chdir(testpackage_directory)
+
+    cli.lint_imports(verbose=verbose)
+
+    captured = capsys.readouterr()
+
+    # N.B. "Wrote data cache file" is logged by Grimp.
+    assert ("Wrote data cache file" in captured.out) == verbose


### PR DESCRIPTION
Uses the new `find_illegal_dependencies_for_layers` provided by Grimp instead of implementing layer checking within Import Linter.

Note: don't merge until the changes have been released in Grimp, and this installs a release.