### PR TITLE
Add ability to have sibling layers

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ Changelog
 
 * Update to Grimp 3.0b3.
 * Use Grimp's find_illegal_dependencies_for_layers method in independence contracts.
+* Add ability to define independent siblings in layers contracts.
 
 1.10.0 (2023-07-06)
 -------------------

--- a/docs/contract_types.rst
+++ b/docs/contract_types.rst
@@ -109,6 +109,10 @@ way around.
 They do this by checking, for an ordered list of modules, that none higher up the list imports anything from a module
 lower down the list, even indirectly.
 
+Additionally, multiple layers can listed on the same line, separated by pipe characters (``|``).These layers will be
+treated as being at the same level in relation to the other layers, but independent with respect to each other. In other
+words, layers on the same line are not allowed to import from each other, nor from any layers above.
+
 Layers are required by default: if a layer is listed in the contract, the contract will be broken if the layer
 doesn't exist. You can make a layer optional by wrapping it in parentheses.
 
@@ -179,6 +183,21 @@ as they are in different containers:
 
 Notice that ``medium`` is an optional layer. This means that if it is missing from any of the containers, Import Linter
 won't complain.
+
+This is an example of a contract with sibling layers:
+
+.. code-block:: ini
+
+    [importlinter:contract:my-layers-contract]
+    name = Contract with sibling layers
+    type = layers
+    layers=
+        high
+        medium_a | medium_b | medium_c
+        low
+
+``medium_a``, ``medium_b`` and ``medium_c`` are three 'sibling' layers that sit immediately below ``high`` and ``low``.
+These must be independent; neither is allow to import from the others.
 
 This is an example of an 'exhaustive' contract.
 


### PR DESCRIPTION
Supports independent sibling layers within a layers contract, using a pipe-separated syntax:

```
    [importlinter:contract:my-layers-contract]
    name = Contract with sibling layers
    type = layers
    layers=
        high
        medium_a | medium_b | medium_c
        low
```
Satisfies https://github.com/seddonym/import-linter/issues/157.