### PR TITLE
Handle multiple modules coming from sibling layers config

### DIFF
--- a/src/importlinter/contracts/layers.py
+++ b/src/importlinter/contracts/layers.py
@@ -222,13 +222,14 @@ class LayersContract(Contract):
         return undeclared_modules
 
     def _check_all_containerless_layers_exist(self, graph: grimp.ImportGraph) -> None:
-        for layer in self.layers:  # type: ignore
-            if layer.is_optional:
-                continue
-            if layer.name not in graph.modules:
-                raise ValueError(
-                    f"Missing layer '{layer.name}': module {layer.name} does not exist."
-                )
+        for layers in self.layers:  # type: ignore
+            for layer in ({layers} if isinstance(layers, Layer) else layers):
+                if layer.is_optional:
+                    continue
+                if layer.name not in graph.modules:
+                    raise ValueError(
+                        f"Missing layer '{layer.name}': module {layer.name} does not exist."
+                    )
 
     def _module_from_layer(self, layer: Layer, container: str | None = None) -> Module:
         if container:

--- a/src/importlinter/contracts/layers.py
+++ b/src/importlinter/contracts/layers.py
@@ -223,7 +223,7 @@ class LayersContract(Contract):
 
     def _check_all_containerless_layers_exist(self, graph: grimp.ImportGraph) -> None:
         for layers in self.layers:  # type: ignore
-            for layer in ({layers} if isinstance(layers, Layer) else layers):
+            for layer in {layers} if isinstance(layers, Layer) else layers:
                 if layer.is_optional:
                     continue
                 if layer.name not in graph.modules:

--- a/tests/unit/contracts/test_layers.py
+++ b/tests/unit/contracts/test_layers.py
@@ -160,7 +160,7 @@ class TestLayerContractSiblingLayers:
                 "layers": [
                     "mypackage.high",
                     "mypackage.medium_a | mypackage.medium_b | mypackage.medium_c",
-                    "mypackage.low"
+                    "mypackage.low",
                 ]
             },
         )

--- a/tests/unit/contracts/test_layers.py
+++ b/tests/unit/contracts/test_layers.py
@@ -152,6 +152,36 @@ class TestLayerContractSiblingLayers:
             "undeclared_modules": set(),
         }
 
+    def test_is_valid_with_minimal_config(self):
+        contract = LayersContract(
+            name="Layer contract",
+            session_options={"root_packages": ["mypackage"]},
+            contract_options={
+                "layers": [
+                    "mypackage.high",
+                    "mypackage.medium_a | mypackage.medium_b | mypackage.medium_c",
+                    "mypackage.low"
+                ]
+            },
+        )
+        graph = ImportGraph()
+        for module in (
+            "mypackage",
+            "mypackage.high",
+            "mypackage.medium_a",
+            "mypackage.medium_b",
+            "mypackage.medium_c",
+            "mypackage.low",
+        ):
+            graph.add_module(module)
+        # Add some 'legal' imports.
+        graph.add_import(importer="mypackage.high.green", imported="mypackage.medium.orange")
+        graph.add_import(importer="mypackage.utils", imported="mypackage.medium.red")
+
+        contract_check = contract.check(graph=graph, verbose=False)
+
+        assert contract_check.kept is True
+
 
 class TestLayerMultipleContainers:
     def test_no_illegal_imports_means_contract_is_kept(self):


### PR DESCRIPTION
I tried out the new sibling layers feature for `layers` contract, but ran in to a bug when trying out the config from documentation:

```
[importlinter:contract:my-layers-contract]
name = Contract with sibling layers
type = layers
layers=
    high
    medium_a | medium_b | medium_c
    low
```

Resulted in a: `'set' object has no attribute 'is_optional'`

The provided changes should ensure both return types(`Layer | set[Layer]`) of `LayerField.parse` are handled