### PR TITLE
Fix: error when using click 6.0 and 7.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Latest
 -------------------
 
 * Officially support Python 3.12.
+* Fix: Error when using `click` version 6.0 and 7.0 (#191).
 
 1.11.1 (2023-08-21)
 -------------------

--- a/src/importlinter/cli.py
+++ b/src/importlinter/cli.py
@@ -20,7 +20,7 @@ EXIT_STATUS_ERROR = 1
 @click.option("--config", default=None, help="The config file to use.")
 @click.option(
     "--contract",
-    default=(),
+    default=[],
     multiple=True,
     help="Limit the check to the supplied contract identifier. May be passed multiple times.",
 )

--- a/src/importlinter/cli.py
+++ b/src/importlinter/cli.py
@@ -20,7 +20,7 @@ EXIT_STATUS_ERROR = 1
 @click.option("--config", default=None, help="The config file to use.")
 @click.option(
     "--contract",
-    default=[],
+    default=list,
     multiple=True,
     help="Limit the check to the supplied contract identifier. May be passed multiple times.",
 )


### PR DESCRIPTION
When using import-linter with click~=6.0 or ~=7.0, below error will occour:

```raw
❯ lint-imports
Traceback (most recent call last):
  File "lint-imports", line 8, in <module>
    sys.exit(lint_imports_command())

... omited ...

  File "lib/python3.8/site-packages/click/core.py", line 1405, in type_cast_value
    raise TypeError('Attempted to invoke composite type '
TypeError: Attempted to invoke composite type but nargs has been set to 0.  This is not supported; nargs needs to be set to a fixed value > 1.
```

Through some investigation, I found that this error was caused by the default value of the "--contract" option. The value was set to an empty tuple in the current codebase, causing the click library to treat it as a "composite type" and misbehave.

This PR fixes that by changing the default to an empty list.