### PR TITLE
Enhance: allow extra empty line & spaces between the module names in the `ignore_imports`

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -19,3 +19,4 @@ Contributors
 * James Owen - https://github.com/leamingrad
 * Matthew Gamble - https://github.com/mwgamble
 * Nick Pope - https://github.com/ngnpope
+* piglei - https://github.com/piglei

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,8 @@ Latest
 
 * Officially support Python 3.12.
 * Fix: Error when using `click` version 6.0 and 7.0 (#191).
+* Enhance: Allow extra whitespace around the module names in the `ignore_imports` config
+* Enhance: Allow blank lines in the `ignore_imports` config
 
 1.11.1 (2023-08-21)
 -------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,8 +6,8 @@ Latest
 
 * Officially support Python 3.12.
 * Fix: Error when using `click` version 6.0 and 7.0 (#191).
-* Enhance: Allow extra whitespace around the module names in the `ignore_imports` config
-* Enhance: Allow blank lines in the `ignore_imports` config
+* Allow extra whitespace around the module names in import expressions.
+* Ignore blank lines in multiple value fields.
 
 1.11.1 (2023-08-21)
 -------------------

--- a/src/importlinter/domain/contract.py
+++ b/src/importlinter/domain/contract.py
@@ -6,11 +6,6 @@ from grimp import ImportGraph
 from . import fields
 
 
-def _is_dummy(v: Any):
-    """Check if an object is dummy."""
-    return isinstance(v, fields.DummyValue)
-
-
 class Contract(abc.ABC):
     def __init__(
         self, name: str, session_options: Dict[str, Any], contract_options: Dict[str, Any]
@@ -48,11 +43,7 @@ class Contract(abc.ABC):
             except fields.ValidationError as e:
                 errors[field_name] = str(e)
                 continue
-
-            # Remove and ignore all "dummy" values
-            no_dummy_data = self._remove_dummy(clean_data)
-            if not _is_dummy(no_dummy_data):
-                setattr(self, field_name, no_dummy_data)
+            setattr(self, field_name, clean_data)
 
         if errors:
             raise InvalidContractOptions(errors)
@@ -78,15 +69,6 @@ class Contract(abc.ABC):
     @classmethod
     def _get_field(cls, field_name: str) -> fields.Field:
         return getattr(cls, field_name)
-
-    @staticmethod
-    def _remove_dummy(value: Any) -> Any:
-        """Try to remove all dummy items."""
-        if isinstance(value, set):
-            return {obj for obj in value if not _is_dummy(obj)}
-        elif isinstance(value, list):
-            return [obj for obj in value if not _is_dummy(obj)]
-        return value
 
     @abc.abstractmethod
     def check(self, graph: ImportGraph, verbose: bool) -> "ContractCheck":

--- a/src/importlinter/domain/contract.py
+++ b/src/importlinter/domain/contract.py
@@ -6,6 +6,11 @@ from grimp import ImportGraph
 from . import fields
 
 
+def _is_dummy(v: Any):
+    """Check if an object is dummy."""
+    return isinstance(v, fields.DummyValue)
+
+
 class Contract(abc.ABC):
     def __init__(
         self, name: str, session_options: Dict[str, Any], contract_options: Dict[str, Any]
@@ -43,7 +48,11 @@ class Contract(abc.ABC):
             except fields.ValidationError as e:
                 errors[field_name] = str(e)
                 continue
-            setattr(self, field_name, clean_data)
+
+            # Remove and ignore all "dummy" values
+            no_dummy_data = self._remove_dummy(clean_data)
+            if not _is_dummy(no_dummy_data):
+                setattr(self, field_name, no_dummy_data)
 
         if errors:
             raise InvalidContractOptions(errors)
@@ -69,6 +78,15 @@ class Contract(abc.ABC):
     @classmethod
     def _get_field(cls, field_name: str) -> fields.Field:
         return getattr(cls, field_name)
+
+    @staticmethod
+    def _remove_dummy(value: Any) -> Any:
+        """Try to remove all dummy items."""
+        if isinstance(value, set):
+            return {obj for obj in value if not _is_dummy(obj)}
+        elif isinstance(value, list):
+            return [obj for obj in value if not _is_dummy(obj)]
+        return value
 
     @abc.abstractmethod
     def check(self, graph: ImportGraph, verbose: bool) -> "ContractCheck":

--- a/src/importlinter/domain/fields.py
+++ b/src/importlinter/domain/fields.py
@@ -1,15 +1,6 @@
 import abc
 from enum import Enum
-from typing import (
-    Generic,
-    Iterable,
-    List,
-    Set,
-    Type,
-    TypeVar,
-    Union,
-    cast,
-)
+from typing import Generic, Iterable, List, Set, Type, TypeVar, Union, cast
 
 from importlinter.domain.imports import ImportExpression, Module
 
@@ -20,10 +11,6 @@ class NotSupplied:
     """Sentinel to use in place of None for a default argument value."""
 
     pass
-
-
-class DummyValue:
-    """A dummy value which should be ignored by the parser."""
 
 
 class ValidationError(Exception):
@@ -125,6 +112,9 @@ class BaseMultipleValueField(Field):
             raw_data = [raw_data]  # Single values should just be treated as a single item list.
         clean_list = []
         for raw_line in raw_data:
+            # Ignore blank lines
+            if not raw_line.strip():
+                continue
             clean_list.append(self.subfield.parse(raw_line))
         return clean_list
 
@@ -181,10 +171,7 @@ class ImportExpressionField(Field):
         "mypackage.**.importer -> mypackage.bar.**"
     """
 
-    def parse(self, raw_data: Union[str, List]) -> Union[ImportExpression, DummyValue]:
-        if isinstance(raw_data, str) and not raw_data.strip():
-            return DummyValue()
-
+    def parse(self, raw_data: Union[str, List]) -> ImportExpression:
         string = StringField().parse(raw_data)
         importer, _, imported = string.partition("->")
         # Remove any whitespace around the module string

--- a/tests/unit/domain/test_fields.py
+++ b/tests/unit/domain/test_fields.py
@@ -14,7 +14,6 @@ from importlinter.domain.fields import (
     SetField,
     StringField,
     ValidationError,
-    DummyValue,
 )
 from importlinter.domain.imports import ImportExpression, Module
 
@@ -180,18 +179,12 @@ class TestImportExpressionField(BaseFieldTest):
     field_class = ImportExpressionField
 
 
-class TestImportExpressionFieldEmptyLine:
-    field = ImportExpressionField()
-    # An empty string which usually works as a separator line in the config file,
-    # it should be treated as a "dummy" value that ignored by the parser.
-    assert isinstance(field.parse(""), DummyValue)
-
-
 @pytest.mark.parametrize(
     "raw_data, expected_value",
     (
         (["mypackage.foo", "mypackage.bar"], [Module("mypackage.foo"), Module("mypackage.bar")]),
         (["mypackage.foo", "mypackage.foo"], [Module("mypackage.foo"), Module("mypackage.foo")]),
+        (["mypackage.foo", "    "], [Module("mypackage.foo")]),
         ("singlevalue", [Module("singlevalue")]),
     ),
 )
@@ -205,6 +198,7 @@ class TestListField(BaseFieldTest):
     (
         (["mypackage.foo", "mypackage.bar"], {Module("mypackage.foo"), Module("mypackage.bar")}),
         (["mypackage.foo", "mypackage.foo"], {Module("mypackage.foo")}),
+        (["mypackage.foo", "    "], {Module("mypackage.foo")}),
         ("singlevalue", {Module("singlevalue")}),
     ),
 )

--- a/tests/unit/domain/test_fields.py
+++ b/tests/unit/domain/test_fields.py
@@ -14,6 +14,7 @@ from importlinter.domain.fields import (
     SetField,
     StringField,
     ValidationError,
+    DummyValue,
 )
 from importlinter.domain.imports import ImportExpression, Module
 
@@ -92,6 +93,10 @@ class TestModuleField(BaseFieldTest):
         (
             "mypackage.foo -> mypackage.bar",
             ImportExpression(importer="mypackage.foo", imported="mypackage.bar"),
+        ),
+        (
+            "my_package.foo   ->   my_package.bar",  # Extra whitespaces are supported.
+            ImportExpression(importer="my_package.foo", imported="my_package.bar"),
         ),
         (
             "my_package.foo -> my_package.foo_bar",  # Underscores are supported.
@@ -173,6 +178,13 @@ class TestModuleField(BaseFieldTest):
 )
 class TestImportExpressionField(BaseFieldTest):
     field_class = ImportExpressionField
+
+
+class TestImportExpressionFieldEmptyLine:
+    field = ImportExpressionField()
+    # An empty string which usually works as a separator line in the config file,
+    # it should be treated as a "dummy" value that ignored by the parser.
+    assert isinstance(field.parse(""), DummyValue)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Enhance: allow extra empty line & spaces between the module names in the `ignore_imports`

The config blow contains some extra spaces and blank lines in the `ignored_imports` section:

```ini
[importlinter]
root_packages =
    foo_proj

[importlinter:contract:layers-main]
name=the main layers
type=layers
layers =
    foo_proj.client
    foo_proj.lib
ignore_imports =
    foo_proj.lib.a     ->   foo_proj.client

    # Some comment
    foo_proj.lib.b -> foo_proj.client
```

In the current version, the linter throws a vague exception. this PR changes the parser to make it work normally.