### PR TITLE
Add missing 'be' in docs: contract_types.rst

### DIFF
--- a/docs/contract_types.rst
+++ b/docs/contract_types.rst
@@ -109,7 +109,7 @@ way around.
 They do this by checking, for an ordered list of modules, that none lower down the list imports anything from a module
 higher up the list, even indirectly.
 
-Additionally, multiple layers can listed on the same line, separated by pipe characters (``|``). These layers will be
+Additionally, multiple layers can be listed on the same line, separated by pipe characters (``|``). These layers will be
 treated as being at the same level in relation to the other layers, but independent with respect to each other. In other
 words, layers on the same line are not allowed to import from each other, nor from any layers below.
 


### PR DESCRIPTION
This looks like it's missing the word 'be' - probably a typing mistake, thought I'd submit a PR while I was looking at it.

Thanks for import-linter!