### PR TITLE
Add support for non-independent sibling modules in layer contracts

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -21,3 +21,4 @@ Contributors
 * Nick Pope - https://github.com/ngnpope
 * piglei - https://github.com/piglei
 * Anton Gruebel - https://github.com/gruebel
+* Peter Byfield - https://github.com/Peter554

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+Unreleased
+----------
+
+* Add support for non-independent sibling modules in layer contracts.
+* In `importlinter.contracts.layers`, `Layer` and `LayerField` 
+  have changed their API slightly. This could impact custom
+  contract types depending on these classes. 
+
 1.12.1 (2023-10-30)
 -------------------
 

--- a/docs/contract_types.rst
+++ b/docs/contract_types.rst
@@ -109,9 +109,11 @@ way around.
 They do this by checking, for an ordered list of modules, that none lower down the list imports anything from a module
 higher up the list, even indirectly.
 
-Additionally, multiple layers can be listed on the same line, separated by pipe characters (``|``). These layers will be
-treated as being at the same level in relation to the other layers, but independent with respect to each other. In other
-words, layers on the same line are not allowed to import from each other, nor from any layers below.
+Additionally, multiple modules can be listed on the same line, separated by pipe characters (``|``). These modules will be
+treated as being at the same layer in relation to the other layers, but independent with respect to each other. In other
+words, modules on the same line are not allowed to import from each other, nor from any layers below. When using the colon 
+character (``:``) to separate the sibling modules within a layer the independence constraint is relaxed - the modules are 
+treated as being at the same layer in relation to the other layers, however are not required to be independent.
 
 Layers are required by default: if a layer is listed in the contract, the contract will be broken if the layer
 doesn't exist. You can make a layer optional by wrapping it in parentheses.
@@ -184,20 +186,35 @@ as they are in different containers:
 Notice that ``medium`` is an optional layer. This means that if it is missing from any of the containers, Import Linter
 won't complain.
 
-This is an example of a contract with sibling layers:
+This is an example of a contract with independent sibling modules:
 
 .. code-block:: ini
 
     [importlinter:contract:my-layers-contract]
-    name = Contract with sibling layers
+    name = Contract with sibling modules (independent)
     type = layers
     layers=
         high
         medium_a | medium_b | medium_c
         low
 
-``medium_a``, ``medium_b`` and ``medium_c`` are three 'sibling' layers that sit immediately below ``high`` and ``low``.
+``medium_a``, ``medium_b`` and ``medium_c`` are three 'sibling' modules that sit immediately below ``high`` and ``low``.
 These must be independent; neither is allow to import from the others.
+
+This is an example of a contract with sibling modules that are not required to be independent:
+
+.. code-block:: ini
+
+    [importlinter:contract:my-layers-contract]
+    name = Contract with sibling modules (not independent)
+    type = layers
+    layers=
+        high
+        medium_a : medium_b : medium_c
+        low
+
+Unlike the previous example, in this case ``medium_a``, ``medium_b`` and ``medium_c``
+are not enforced as independent, so are allowed to import from each other.
 
 This is an example of an 'exhaustive' contract.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ authors = [
 requires-python = ">=3.8"
 dependencies = [
     "click>=6",
-    "grimp>=3.1",
+    "grimp>=3.2",
     "tomli>=1.2.1; python_version < '3.11'",
     "typing-extensions>=3.10.0.0",
 ]

--- a/src/importlinter/contracts/layers.py
+++ b/src/importlinter/contracts/layers.py
@@ -288,6 +288,9 @@ class LayersContract(Contract):
     @staticmethod
     def _grimpify_layers(layers: list[Layer]) -> list[grimp.Layer]:
         return [
-            grimp.Layer(*{module_tail.name for module_tail in layer.module_tails})
+            grimp.Layer(
+                *{module_tail.name for module_tail in layer.module_tails},
+                independent=layer.is_independent,
+            )
             for layer in layers
         ]

--- a/src/importlinter/contracts/layers.py
+++ b/src/importlinter/contracts/layers.py
@@ -30,6 +30,7 @@ class ModuleTail:
 @dataclass(frozen=True)
 class Layer:
     module_tails: set[ModuleTail]
+    is_independent: bool = True
 
 
 class LayerField(fields.Field):
@@ -45,7 +46,7 @@ class LayerField(fields.Field):
                 module_tail = raw_item
                 is_optional = False
             module_tails.add(ModuleTail(name=module_tail, is_optional=is_optional))
-        return Layer(module_tails)
+        return Layer(module_tails, is_independent=True)
 
 
 class _LayerChainData(TypedDict):

--- a/tests/unit/contracts/test_layers.py
+++ b/tests/unit/contracts/test_layers.py
@@ -2,7 +2,7 @@ import pytest
 from grimp.adaptors.graph import ImportGraph
 
 from importlinter.application.app_config import settings
-from importlinter.contracts.layers import Layer, LayerField, LayersContract
+from importlinter.contracts.layers import Layer, LayerField, LayersContract, ModuleTail
 from importlinter.domain.contract import ContractCheck, InvalidContractOptions
 from importlinter.domain.helpers import MissingImport
 from tests.adapters.printing import FakePrinter
@@ -17,12 +17,21 @@ def configure():
 @pytest.mark.parametrize(
     "data, parsed_data",
     (
-        ("one", Layer(name="one", is_optional=False)),
-        ("(one)", Layer(name="one", is_optional=True)),
-        ("one | two |    three", {Layer(name="one"), Layer(name="two"), Layer(name="three")}),
+        ("one", Layer({ModuleTail(name="one", is_optional=False)})),
+        ("(one)", Layer({ModuleTail(name="one", is_optional=True)})),
+        (
+            "one | two |    three",
+            Layer({ModuleTail(name="one"), ModuleTail(name="two"), ModuleTail(name="three")}),
+        ),
         (
             "one | (two) | three",
-            {Layer(name="one"), Layer(name="two", is_optional=True), Layer(name="three")},
+            Layer(
+                {
+                    ModuleTail(name="one"),
+                    ModuleTail(name="two", is_optional=True),
+                    ModuleTail(name="three"),
+                }
+            ),
         ),
     ),
 )


### PR DESCRIPTION
This PR contains the changes needed within import-linter to support https://github.com/seddonym/import-linter/issues/208.

This continues the prerequisite work in grimp to support this feature https://github.com/seddonym/grimp/pull/136. 