### PR TITLE
Add as_packages to Forbidden contracts

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -24,3 +24,4 @@ Contributors
 * Peter Byfield - https://github.com/Peter554
 * Fabian Binz - https://github.com/fbinz
 * Neil Williams - https://github.com/spladug
+* Nicholas Bunn - https://github.com/NicholasBunn

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+latest
+------
+
+* Add as_packages field to forbidden contracts.
+
 2.2 (2025-02-07)
 ----------------
 

--- a/docs/contract_types.rst
+++ b/docs/contract_types.rst
@@ -11,8 +11,10 @@ Forbidden modules
 
 Forbidden contracts check that one set of modules are not imported by another set of modules.
 
-Descendants of each module will be checked - so if ``mypackage.one`` is forbidden from importing ``mypackage.two``, then
-``mypackage.one.blue`` will be forbidden from importing ``mypackage.two.green``. Indirect imports will also be checked.
+By default, descendants of each module will be checked - so if ``mypackage.one`` is forbidden from importing ``mypackage.two``, then
+``mypackage.one.blue`` will be forbidden from importing ``mypackage.two.green``. Indirect imports will also be checked. This
+descendant behaviour can be changed by setting ``as_packages`` to ``False``: in that case, only explicitly listed modules will be
+checked, not their descendants.
 
 External packages may also be forbidden.
 
@@ -66,6 +68,9 @@ External packages may also be forbidden.
     - ``unmatched_ignore_imports_alerting``: See :ref:`Shared options`.
     - ``allow_indirect_imports``: If ``True``, allow indirect imports to forbidden modules without interpreting them
       as a reason to mark the contract broken. (Optional.)
+    - ``as_packages``: Whether to treat the source and forbidden modules as packages. If ``False``, each of the modules
+      passed in will be treated as a module rather than a package. Default behaviour is ``True`` (treat modules as
+      packages).
 
 Independence
 ------------


### PR DESCRIPTION
Following on from the work to add further `as_packages` support to Grimp [here](https://github.com/seddonym/grimp/pull/157/files#diff-97edc3a895c7938b1e9c18d493b37de3f1e4d448a34ca925caf3df1e9c975f47), this PR adds the `as_packages` options to Forbidden contracts so that we can forbid modules in addition to entire packages. The default behaviour remains, treating all imports as packages

This change would serve to fix [this](https://github.com/seddonym/import-linter/issues/199) issue (or implement the feature, I guess?)