### PR TITLE
Improve setup and docs

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -52,20 +52,41 @@ To set up `import-linter` for local development:
 
     git clone git@github.com:your_name_here/import-linter.git
 
+3. Setup venv::
+
+    virtualenv venv
+
+    # On macOS/Linux:
+    source venv/bin/activate
+    # On Windows:
+    .\venv\Scripts\activate
+
+    pip install -e .
+    pip install -r requirements-dev.txt
+
 3. Create a branch for local development::
 
     git checkout -b name-of-your-bugfix-or-feature
 
    Now you can make your changes locally.
 
-4. When you're done making changes, run all the checks with `tox <https://tox.wiki/en/latest/installation.html>`_ one command::
+4. Run tests/checks::
+
+    pytest
+    black src tests
+    flake8 src tests
+    mypy src tests
+    isort src tests
+    lint-imports
+
+5. When you're done making changes, run all the checks with `tox <https://tox.wiki/en/latest/installation.html>`_ one command::
 
     tox
 
-5. Commit your changes and push your branch to GitHub::
+6. Commit your changes and push your branch to GitHub::
 
     git add .
     git commit -m "Your detailed description of your changes."
     git push origin name-of-your-bugfix-or-feature
 
-6. Submit a pull request through the GitHub website.
+7. Submit a pull request through the GitHub website.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,17 +58,29 @@ namespaces = false
 
 [tool.black]
 line-length = 99
+extend-exclude = '''
+/(
+    docs
+    |venv
+    |\.tox
+)/
+'''
 
 [tool.isort]
+profile = "black"
 multi_line_output = 3
 include_trailing_comma = "True"
 force_grid_wrap = 0
 use_parentheses = "True"
 line_length = 99
+skip = ["docs", "venv", ".tox"]
 
 [tool.mypy]
 exclude = [
     '^tests/assets/',
+    '^docs/*',
+    '^venv/*',
+    '^\.tox/',
 ]
 warn_unused_ignores = true
 warn_redundant_casts = true

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,7 @@
+PyYAML~=6.0.1
+black~=22.3.0
+flake8~=4.0.1
+mypy~=0.730
+pytest~=7.4.0
+pytest-cov~=4.1.0
+types-PyYAML

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,9 @@
 [flake8]
 ignore = E731, E203, W503
 max-line-length = 100
-exclude = */migrations/*, tests/assets/*
+exclude =
+    */migrations/*,
+    tests/assets/*,
+    .tox,
+    docs,
+    venv

--- a/src/importlinter/adapters/user_options.py
+++ b/src/importlinter/adapters/user_options.py
@@ -1,7 +1,7 @@
-import configparser
-from typing import Any, Dict, Optional, List
 import abc
+import configparser
 import sys
+from typing import Any, Dict, List, Optional
 
 if sys.version_info >= (3, 11):
     import tomllib

--- a/src/importlinter/application/contract_utils.py
+++ b/src/importlinter/application/contract_utils.py
@@ -1,11 +1,11 @@
 import enum
 from typing import List, Optional, Sequence, Set
 
+from grimp import ImportGraph
 
 from importlinter.domain import helpers
 from importlinter.domain.helpers import MissingImport
 from importlinter.domain.imports import ImportExpression
-from grimp import ImportGraph
 
 
 class AlertLevel(enum.Enum):

--- a/src/importlinter/application/ports/reporting.py
+++ b/src/importlinter/application/ports/reporting.py
@@ -1,7 +1,8 @@
 from typing import Dict, Iterator, List, Tuple
 
-from importlinter.domain.contract import Contract, ContractCheck, InvalidContractOptions
 from grimp import ImportGraph
+
+from importlinter.domain.contract import Contract, ContractCheck, InvalidContractOptions
 
 
 class Reporter:

--- a/src/importlinter/cli.py
+++ b/src/importlinter/cli.py
@@ -1,13 +1,14 @@
 import os
 import sys
 from logging import config as logging_config
-from typing import NoReturn, Optional, Tuple, Type, Union
+from typing import Optional, Tuple, Type, Union
 
 import click
 
-from importlinter import configuration
-from importlinter.application import use_cases
 from importlinter.application.sentinels import NotSupplied
+
+from . import configuration
+from .application import use_cases
 
 configuration.configure()
 
@@ -36,7 +37,6 @@ EXIT_STATUS_ERROR = 1
     is_flag=True,
     help="Noisily output progress as we go along.",
 )
-@click.argument("files", nargs=-1, type=click.Path(exists=True))
 def lint_imports_command(
     config: Optional[str],
     contract: Tuple[str, ...],
@@ -45,8 +45,7 @@ def lint_imports_command(
     debug: bool,
     show_timings: bool,
     verbose: bool,
-    files: Tuple[str, ...],
-) -> NoReturn:
+) -> int:
     """
     Check that a project adheres to a set of contracts.
     """
@@ -58,7 +57,6 @@ def lint_imports_command(
         is_debug_mode=debug,
         show_timings=show_timings,
         verbose=verbose,
-        files=files,
     )
     sys.exit(exit_code)
 
@@ -71,7 +69,6 @@ def lint_imports(
     is_debug_mode: bool = False,
     show_timings: bool = False,
     verbose: bool = False,
-    files: Tuple[str, ...] = (),
 ) -> int:
     """
     Check that a project adheres to a set of contracts.
@@ -88,7 +85,6 @@ def lint_imports(
         show_timings:       whether to show the times taken to build the graph and to check
                             each contract.
         verbose:            if True, noisily output progress as it goes along.
-        files:              the files to lint. If not provided, the entire project is linted.
 
     Returns:
         EXIT_STATUS_SUCCESS or EXIT_STATUS_ERROR.
@@ -146,7 +142,3 @@ def _configure_logging(verbose: bool) -> None:
             },
         }
     )
-
-
-if __name__ == "__main__":
-    lint_imports_command()

--- a/src/importlinter/cli.py
+++ b/src/importlinter/cli.py
@@ -1,14 +1,13 @@
 import os
 import sys
 from logging import config as logging_config
-from typing import Optional, Tuple, Type, Union
+from typing import NoReturn, Optional, Tuple, Type, Union
 
 import click
 
+from importlinter import configuration
+from importlinter.application import use_cases
 from importlinter.application.sentinels import NotSupplied
-
-from . import configuration
-from .application import use_cases
 
 configuration.configure()
 
@@ -37,6 +36,7 @@ EXIT_STATUS_ERROR = 1
     is_flag=True,
     help="Noisily output progress as we go along.",
 )
+@click.argument("files", nargs=-1, type=click.Path(exists=True))
 def lint_imports_command(
     config: Optional[str],
     contract: Tuple[str, ...],
@@ -45,7 +45,8 @@ def lint_imports_command(
     debug: bool,
     show_timings: bool,
     verbose: bool,
-) -> int:
+    files: Tuple[str, ...],
+) -> NoReturn:
     """
     Check that a project adheres to a set of contracts.
     """
@@ -57,6 +58,7 @@ def lint_imports_command(
         is_debug_mode=debug,
         show_timings=show_timings,
         verbose=verbose,
+        files=files,
     )
     sys.exit(exit_code)
 
@@ -69,6 +71,7 @@ def lint_imports(
     is_debug_mode: bool = False,
     show_timings: bool = False,
     verbose: bool = False,
+    files: Tuple[str, ...] = (),
 ) -> int:
     """
     Check that a project adheres to a set of contracts.
@@ -85,6 +88,7 @@ def lint_imports(
         show_timings:       whether to show the times taken to build the graph and to check
                             each contract.
         verbose:            if True, noisily output progress as it goes along.
+        files:              the files to lint. If not provided, the entire project is linted.
 
     Returns:
         EXIT_STATUS_SUCCESS or EXIT_STATUS_ERROR.
@@ -142,3 +146,7 @@ def _configure_logging(verbose: bool) -> None:
             },
         }
     )
+
+
+if __name__ == "__main__":
+    lint_imports_command()

--- a/src/importlinter/contracts/independence.py
+++ b/src/importlinter/contracts/independence.py
@@ -13,12 +13,7 @@ from importlinter.domain.contract import Contract, ContractCheck
 from importlinter.domain.helpers import module_expressions_to_modules
 from importlinter.domain.imports import Module
 
-from ._common import (
-    DetailedChain,
-    Link,
-    build_detailed_chain_from_route,
-    render_chain_data,
-)
+from ._common import DetailedChain, Link, build_detailed_chain_from_route, render_chain_data
 
 
 class _SubpackageChainData(TypedDict):

--- a/src/importlinter/contracts/layers.py
+++ b/src/importlinter/contracts/layers.py
@@ -14,7 +14,6 @@ from importlinter.domain.imports import Module
 
 from ._common import DetailedChain, build_detailed_chain_from_route, render_chain_data
 
-
 _INDEPENDENT_LAYER_DELIMITER = "|"
 _NON_INDEPENDENT_LAYER_DELIMITER = ":"
 

--- a/src/importlinter/domain/helpers.py
+++ b/src/importlinter/domain/helpers.py
@@ -4,12 +4,7 @@ from typing import Iterable, List, Pattern, Set, Tuple
 
 from grimp import DetailedImport, ImportGraph
 
-from importlinter.domain.imports import (
-    DirectImport,
-    ImportExpression,
-    Module,
-    ModuleExpression,
-)
+from importlinter.domain.imports import DirectImport, ImportExpression, Module, ModuleExpression
 
 
 class MissingImport(Exception):

--- a/tests/assets/multipleroots/rootpackageblue/one/alpha.py
+++ b/tests/assets/multipleroots/rootpackageblue/one/alpha.py
@@ -1,4 +1,5 @@
 import sys  # Standard library import.
+
 import pytest  # Third party library import.
 
 BAR = "bar"

--- a/tests/assets/testpackage/testpackage/utils.py
+++ b/tests/assets/testpackage/testpackage/utils.py
@@ -1,3 +1,2 @@
 from pytest import mark
-
 from testpackage.high import green

--- a/tests/helpers/contracts.py
+++ b/tests/helpers/contracts.py
@@ -1,7 +1,8 @@
+from grimp import ImportGraph
+
 from importlinter.application import output
 from importlinter.domain import fields
 from importlinter.domain.contract import Contract, ContractCheck
-from grimp import ImportGraph
 
 
 class AlwaysPassesContract(Contract):

--- a/tests/unit/contracts/test_layers.py
+++ b/tests/unit/contracts/test_layers.py
@@ -3,9 +3,9 @@ from grimp.adaptors.graph import ImportGraph
 
 from importlinter.application.app_config import settings
 from importlinter.contracts.layers import Layer, LayerField, LayersContract, ModuleTail
+from importlinter.domain import fields
 from importlinter.domain.contract import ContractCheck, InvalidContractOptions
 from importlinter.domain.helpers import MissingImport
-from importlinter.domain import fields
 from tests.adapters.printing import FakePrinter
 from tests.adapters.timing import FakeTimer
 

--- a/tox.ini
+++ b/tox.ini
@@ -22,9 +22,7 @@ passenv =
     *
 usedevelop = false
 deps =
-    pytest~=7.4.0
-    pytest-cov~=4.1.0
-    PyYAML~=6.0.1
+    -r requirements-dev.txt
 commands =
     {posargs:pytest --cov --cov-report=term-missing -vv tests}
 
@@ -32,14 +30,11 @@ commands =
 [testenv:check]
 deps =
     {[testenv]deps}
-    black~=22.3.0
-    flake8~=4.0.1
-    mypy~=0.730
-    types-PyYAML
 commands =
     black --check src tests
     flake8 src tests
-    mypy src/importlinter tests
+    mypy src tests
+    isort --check src tests
     lint-imports
 
 [testenv:docs]

--- a/tox.ini
+++ b/tox.ini
@@ -32,9 +32,9 @@ deps =
     {[testenv]deps}
 commands =
     black --check src tests
+    isort --check src tests
     flake8 src tests
     mypy src tests
-    isort --check src tests
     lint-imports
 
 [testenv:docs]


### PR DESCRIPTION
Just adding a bit more docs on getting setup, just feedback from a first timer setting up the repo :)

I went with a basic requirements-dev.txt to hold the requirements in one spot (updated tox to reference them as well) - but maybe consider poetry? 

I also tweaked the black, isort, mypy configs so they all run using `<command> .` (and only runs on project files) - for me I think that's kind of convention for those tools.

I also ran isort, and added to tox.ini