### PR TITLE
Improve error messages when contract has missing/invalid type or missing name

### DIFF
--- a/src/importlinter/application/use_cases.py
+++ b/src/importlinter/application/use_cases.py
@@ -182,8 +182,8 @@ def _build_report(
         user_options.contracts_options, limit_to_contracts
     )
     for contract_options in contracts_options:
-        contract_class = registry.get_contract_class(contract_options["type"])
         try:
+            contract_class = _get_contract_class(contract_options)
             contract = contract_class(
                 name=contract_options["name"],
                 session_options=user_options.session_options,
@@ -205,6 +205,14 @@ def _build_report(
 
     output.verbose_print(verbose, newline=True)
     return report
+
+
+def _get_contract_class(contract_options: Dict[str, Any]) -> Type[Contract]:
+    if "type" not in contract_options:
+        raise InvalidContractOptions(
+            {"type": "Unable to find the 'type' key in the contract options."}
+        )
+    return registry.get_contract_class(contract_options["type"])
 
 
 def _filter_contract_options(

--- a/src/importlinter/application/use_cases.py
+++ b/src/importlinter/application/use_cases.py
@@ -187,15 +187,16 @@ def _build_report(
         user_options.contracts_options, limit_to_contracts
     )
     for contract_options in contracts_options:
+        contract_name = contract_options.get("name", contract_options['id'])
         try:
             contract_class = _get_contract_class(contract_options)
             contract = contract_class(
-                name=contract_options["name"],
+                name=contract_name,
                 session_options=user_options.session_options,
                 contract_options=contract_options,
             )
         except InvalidContractOptions as e:
-            report.add_invalid_contract_options(contract_options["name"], e)
+            report.add_invalid_contract_options(contract_name, e)
             return report
 
         output.verbose_print(verbose, f"Checking {contract.name}...")

--- a/src/importlinter/application/use_cases.py
+++ b/src/importlinter/application/use_cases.py
@@ -5,7 +5,12 @@ from typing import Any, Dict, List, Optional, Tuple, Type, Union
 from grimp import ImportGraph
 
 from ..application import rendering
-from ..domain.contract import Contract, InvalidContractOptions, registry
+from ..domain.contract import (
+    Contract,
+    InvalidContractOptions,
+    NoSuchContractType,
+    registry,
+)
 from . import output
 from .app_config import settings
 from .ports.reporting import Report
@@ -212,7 +217,10 @@ def _get_contract_class(contract_options: Dict[str, Any]) -> Type[Contract]:
         raise InvalidContractOptions(
             {"type": "Unable to find the 'type' key in the contract options."}
         )
-    return registry.get_contract_class(contract_options["type"])
+    try:
+        return registry.get_contract_class(contract_options["type"])
+    except NoSuchContractType as e:
+        raise InvalidContractOptions({"type": f"Uknown contract type '{e}'."})
 
 
 def _filter_contract_options(


### PR DESCRIPTION
Each change is implemented in a separate commit for easier review. Let me know what you think.

When the contract type is missing from options, the error message now becomes:

```
Contract "My Contract" is not configured correctly:
    type: Unable to find the 'type' key in the contract options.
```

When the contract type is not known or registered, the error message now becomes:
```
Contract "My Contract" is not configured correctly:
    type: Unknown contract type: my-contract-type
```

When the contract has no configured name, it will now use the contract id as a fallback:
```
Contract "2" is not configured correctly:
    type: Unknown contract type: my-contract-type
```