### PR TITLE
Update contract utils to delegate module expression matching to grimp

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ authors = [
 requires-python = ">=3.9"
 dependencies = [
     "click>=6",
-    "grimp>=3.2",
+    "grimp>=3.7",
     "tomli>=1.2.1; python_version < '3.11'",
     "typing-extensions>=3.10.0.0",
 ]

--- a/src/importlinter/application/contract_utils.py
+++ b/src/importlinter/application/contract_utils.py
@@ -2,9 +2,8 @@ import enum
 from typing import List, Optional, Sequence, Set
 
 
-from importlinter.domain import helpers
 from importlinter.domain.helpers import MissingImport
-from importlinter.domain.imports import ImportExpression
+from importlinter.domain.imports import ImportExpression, DirectImport, Module
 from grimp import ImportGraph
 
 
@@ -33,16 +32,35 @@ def remove_ignored_imports(
     Returns:
         A list of any warnings to be surfaced to the user.
     """
-    imports, unresolved_expressions = helpers.resolve_import_expressions(
-        graph=graph, expressions=ignore_imports if ignore_imports else []
-    )
+    imports_to_remove = set()
+    unresolved_expressions = set()
+    for import_expression in ignore_imports or []:
+        matched_imports = graph.find_matching_direct_imports(
+            import_expression=str(import_expression)
+        )
+        if matched_imports:
+            imports_to_remove.update(
+                {
+                    DirectImport(
+                        importer=Module(matched_import["importer"]),
+                        imported=Module(matched_import["imported"]),
+                    )
+                    for matched_import in matched_imports
+                }
+            )
+        else:
+            unresolved_expressions.add(import_expression)
 
     warnings = _handle_unresolved_import_expressions(
         unresolved_expressions,
         unmatched_alerting,
     )
 
-    helpers.pop_imports(graph, imports)
+    for import_to_remove in imports_to_remove:
+        graph.remove_import(
+            importer=import_to_remove.importer.name,
+            imported=import_to_remove.imported.name,
+        )
 
     return warnings
 


### PR DESCRIPTION
This PR updates the import-linter contract utils to defer module expression matching to grimp. This is now possible, since low level module expression functionality was included in grimp 3.7 (see https://github.com/seddonym/grimp/pull/192).

This gives a nice performance boost. For example, `remove_ignored_imports` will now be much more efficient when matching many imports.


**Before (my machine):**

```
lint-imports --config ../.importlinter/territories.ini --show-timings
...
GBR territory-level code should not import energy market code KEPT [13s]
...
```

**After (my machine):**

```
lint-imports --config ../.importlinter/territories.ini --show-timings
...
GBR territory-level code should not import energy market code KEPT [0s]
...
```

Grimp does not yet have any `grimp.ModuleExpression`/`grimp.ImportExpression` in its public API, nor does it yet have any way to directly validate a module expression. Therefore, for now the validation logic for module expressions is duplicated in both grimp and import-linter. It's likely that we'd want to deduplicate that as follow up work. From slack:

> @seddonym: But I would say this is fairly low priority - it’s fine for Import Linter to duplicate the validation logic for the time being.