### PR TITLE
Fix bug with ModuleExpression repr

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ latest
 - Fixed incorrect handling of unicode characters in TOML files on Windows.
 - Changed pre-commit hook to use the system virtualenv and to run whenever
   any file changes, not just a Python file.
+- Fix RecursionError when running repr on a ModuleExpression.
 
 2.3 (2025-03-11)
 ----------------

--- a/src/importlinter/domain/imports.py
+++ b/src/importlinter/domain/imports.py
@@ -103,6 +103,9 @@ class ModuleExpression(ValueObject):
     def has_wildcard_expression(self) -> bool:
         return "*" in self.expression
 
+    def __str__(self) -> str:
+        return self.expression
+
 
 class ImportExpression(ValueObject):
     """

--- a/tests/unit/domain/test_imports.py
+++ b/tests/unit/domain/test_imports.py
@@ -96,6 +96,12 @@ class TestDirectImport:
         assert str(test_object) == expected_string
 
 
+class TestModuleExpression:
+    def test_object_representation(self):
+        expression = ModuleExpression("mypackage.foo.**")
+        assert repr(expression) == "<ModuleExpression: mypackage.foo.**>"
+
+
 class TestImportExpression:
     def test_object_representation(self):
         test_object = ImportExpression(


### PR DESCRIPTION
Prior to this commit, repr(ModuleExpression(...)) would raise a RecursionError.