### PR TITLE
Fix messages being always colored white on Windows

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -26,3 +26,4 @@ Contributors
 * Neil Williams - https://github.com/spladug
 * Nicholas Bunn - https://github.com/NicholasBunn
 * Felix Uhl - https://github.com/iFreilicht
+* Ilya S. (Tapeline) - https://github.com/Tapeline

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ latest
 - Changed pre-commit hook to use the system virtualenv and to run whenever
   any file changes, not just a Python file.
 - Fix RecursionError when running repr on a ModuleExpression.
+- Fix messages being always colored white on Windows.
 
 2.3 (2025-03-11)
 ----------------

--- a/src/importlinter/adapters/printing.py
+++ b/src/importlinter/adapters/printing.py
@@ -13,4 +13,6 @@ class ClickPrinter(Printer):
     def print(
         self, text: str = "", bold: bool = False, color: Optional[str] = None, newline: bool = True
     ) -> None:
-        click.secho(text, bold=bold, fg=color, nl=newline)
+        # A tricky solution to gh-267
+        # Remove when click reaches v9.0.0
+        print(click.style(text, bold=bold, fg=color), end=("\n" if newline else ""))

--- a/src/importlinter/adapters/printing.py
+++ b/src/importlinter/adapters/printing.py
@@ -13,6 +13,7 @@ class ClickPrinter(Printer):
     def print(
         self, text: str = "", bold: bool = False, color: Optional[str] = None, newline: bool = True
     ) -> None:
+        # click.secho(text, bold=bold, fg=color, nl=newline)
         # A tricky solution to gh-267
         # Remove when click reaches v9.0.0
         print(click.style(text, bold=bold, fg=color), end=("\n" if newline else ""))

--- a/src/importlinter/application/ports/reporting.py
+++ b/src/importlinter/application/ports/reporting.py
@@ -4,11 +4,11 @@ from importlinter.domain.contract import Contract, ContractCheck, InvalidContrac
 from grimp import ImportGraph
 
 
-class Reporter: 
+class Reporter:
     ...
 
 
-class ExceptionReporter: 
+class ExceptionReporter:
     ...
 
 

--- a/src/importlinter/application/ports/reporting.py
+++ b/src/importlinter/application/ports/reporting.py
@@ -4,12 +4,10 @@ from importlinter.domain.contract import Contract, ContractCheck, InvalidContrac
 from grimp import ImportGraph
 
 
-class Reporter:
-    ...
+class Reporter: ...
 
 
-class ExceptionReporter:
-    ...
+class ExceptionReporter: ...
 
 
 class Report:

--- a/src/importlinter/application/ports/reporting.py
+++ b/src/importlinter/application/ports/reporting.py
@@ -4,10 +4,12 @@ from importlinter.domain.contract import Contract, ContractCheck, InvalidContrac
 from grimp import ImportGraph
 
 
-class Reporter: ...
+class Reporter: 
+    ...
 
 
-class ExceptionReporter: ...
+class ExceptionReporter: 
+    ...
 
 
 class Report:


### PR DESCRIPTION
### Description
Fix messages being always colored white on Windows by temporary switching to default `print` in `ClickPrinter`.

### Fixes
- #267 