### PR TITLE
Make forbidden contract docstring consistent with other contracts

### DIFF
--- a/src/importlinter/contracts/forbidden.py
+++ b/src/importlinter/contracts/forbidden.py
@@ -19,6 +19,7 @@ class ForbiddenContract(Contract):
     """
     Forbidden contracts check that one set of modules are not imported by another set of modules.
     Indirect imports will also be checked.
+
     Configuration options:
         - source_modules:    A set of Modules that should not import the forbidden modules.
         - forbidden_modules: A set of Modules that should not be imported by the source modules.


### PR DESCRIPTION
Following [this comment](https://github.com/seddonym/import-linter/pull/266#discussion_r2197696947) I realized forbidden contract docstring had a small inconsistency. This PR fixes it.