### PR TITLE
Upgrade tox requirements to latest versions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,11 +3,12 @@ Changelog
 
 latest
 ------
-- Fix incorrect handling of unicode characters in TOML files on Windows.
-- Changed pre-commit hook to use the system virtualenv and to run whenever
+* Fix incorrect handling of unicode characters in TOML files on Windows.
+* Change pre-commit hook to use the system virtualenv and to run whenever
   any file changes, not just a Python file.
-- Fix RecursionError when running repr on a ModuleExpression.
-- Fix messages being always colored white on Windows.
+* Fix RecursionError when running repr on a ModuleExpression.
+* Fix messages being always colored white on Windows.
+* Upgrade latest tox requirements (fixing error with `tox -echeck`).
 
 2.3 (2025-03-11)
 ----------------

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,4 @@
 [flake8]
-ignore = E731, E203, W503
+ignore =  E701, E731, E203, W503,
 max-line-length = 100
 exclude = */migrations/*, tests/assets/*

--- a/src/importlinter/application/ports/reporting.py
+++ b/src/importlinter/application/ports/reporting.py
@@ -4,12 +4,10 @@ from importlinter.domain.contract import Contract, ContractCheck, InvalidContrac
 from grimp import ImportGraph
 
 
-class Reporter:
-    ...
+class Reporter: ...
 
 
-class ExceptionReporter:
-    ...
+class ExceptionReporter: ...
 
 
 class Report:

--- a/tox.ini
+++ b/tox.ini
@@ -22,9 +22,9 @@ passenv =
     *
 usedevelop = false
 deps =
-    pytest~=7.4.0
-    pytest-cov~=4.1.0
-    PyYAML~=6.0.1
+    pytest~=8.4.1
+    pytest-cov~=6.2.1
+    PyYAML~=6.0.2
 commands =
     {posargs:pytest --cov --cov-report=term-missing -vv tests}
 
@@ -32,10 +32,10 @@ commands =
 [testenv:check]
 deps =
     {[testenv]deps}
-    black~=22.3.0
-    flake8~=4.0.1
-    mypy~=0.730
-    types-PyYAML
+    black~=25.1.0
+    flake8~=7.3.0
+    mypy~=1.17.0
+    types-PyYAML~=6.0.12
 commands =
     black --check src tests
     flake8 src tests
@@ -50,7 +50,7 @@ commands =
     sphinx-build -b linkcheck docs dist/docs
 
 [testenv:report]
-deps = coverage~=6.3.1
+deps = coverage~=7.9.2
 skip_install = true
 commands =
     coverage report


### PR DESCRIPTION
Prior to this, `tox -echeck` was erroring with `AttributeError: 'EntryPoints' object has no attribute 'get'`. Upgrading flake8 seems to fix it. I've taken the opportunity to upgrade the other tox dependencies to their latest versions.

This necessitated a couple of tweaks to take account of the new version of Black.

Mentioned in https://github.com/seddonym/import-linter/pull/272