### PR TITLE
Rename default branch to 'main'

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,9 +3,9 @@ name: CI
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
-    branches: [master]
+    branches: [main]
   workflow_dispatch:
 
 jobs:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,7 @@ latest
 * Fix RecursionError when running repr on a ModuleExpression.
 * Fix messages being always colored white on Windows.
 * Upgrade latest tox requirements (fixing error with `tox -echeck`).
+* Rename default Git repository branch to 'main'.
 
 2.3 (2025-03-11)
 ----------------

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -76,7 +76,7 @@ Releasing to Pypi
 (Only maintainers can do this.)
 
 1. Choose a new version number (based on `semver <https://semver.org/>`_).
-2. ``git pull origin master``
+2. ``git pull origin main``
 3. Update ``CHANGELOG.rst`` with the new version number.
 4. Update the ``release`` variable in ``docs/conf.py`` with the new version number.
 5. Update the ``__version__`` variable in ``src/importlinter/__init__.py`` with the new version number.

--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@ Import Linter
     :alt: Python versions
     :target: https://pypi.org/project/import-linter/
 
-.. image:: https://github.com/seddonym/import-linter/workflows/CI/badge.svg?branch=master
+.. image:: https://github.com/seddonym/import-linter/workflows/CI/badge.svg?branch=main
      :target: https://github.com/seddonym/import-linter/actions?workflow=CI
      :alt: CI Status
 


### PR DESCRIPTION
The actual rename is done within Github; this makes the necessary changes.