### PR TITLE
Milliseconds timings

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -27,3 +27,4 @@ Contributors
 * Nicholas Bunn - https://github.com/NicholasBunn
 * Felix Uhl - https://github.com/iFreilicht
 * Ilya S. (Tapeline) - https://github.com/Tapeline
+* Uberto Barbini - https://github.com/uberto

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,7 @@ latest
 * Fix messages being always colored white on Windows.
 * Upgrade latest tox requirements (fixing error with `tox -echeck`).
 * Rename default Git repository branch to 'main'.
+* Changed timings to show 1 decimal under 10s and 3 decimals under 1s.
 
 2.3 (2025-03-11)
 ----------------

--- a/src/importlinter/adapters/timing.py
+++ b/src/importlinter/adapters/timing.py
@@ -4,5 +4,6 @@ from importlinter.application.ports.timing import Timer
 
 
 class SystemClockTimer(Timer):
-    def get_current_time(self) -> float:
-        return time.time()
+    def get_current_time_ms(self) -> int:
+        # Use high-resolution monotonic clock and convert to integer milliseconds (rounded).
+        return (time.perf_counter_ns() + 500_000) // 1_000_000

--- a/src/importlinter/application/ports/reporting.py
+++ b/src/importlinter/application/ports/reporting.py
@@ -22,6 +22,7 @@ class Report:
         self.contains_failures = False
         self.contracts: List[Contract] = []
         self._check_map: Dict[Contract, ContractCheck] = {}
+        # Durations are stored as integer milliseconds
         self._durations: Dict[Contract, int] = {}
         self.warnings_count = 0
         self.broken_count = 0

--- a/src/importlinter/application/ports/timing.py
+++ b/src/importlinter/application/ports/timing.py
@@ -9,21 +9,21 @@ class Timer(abc.ABC):
     Context manager to allow easy timing of events.
 
     This is an abstraction that needs to be implemented using a subclass
-    that implements the get_current_time method.
+    that implements the get_current_time_ms method.
 
     Usage:
 
         with Timer() as timer:
             do_something()
-        print(timer.duration_in_s)
+        print(timer.duration_in_ms)
     """
 
     def __init__(self) -> None:
         # We use a stack so context managers can be nested.
-        self._start_stack: list[float] = []
+        self._start_stack_ms: list[int] = []
 
     def __enter__(self) -> Timer:
-        self._start_stack.append(self.get_current_time())
+        self._start_stack_ms.append(self.get_current_time_ms())
         return self
 
     def __exit__(
@@ -32,15 +32,21 @@ class Timer(abc.ABC):
         exc_val: BaseException | None,
         exc_tb: TracebackType | None,
     ) -> None:
-        end = self.get_current_time()
-        start = self._start_stack.pop()
-        self.duration_in_s = int(end - start)
+        end_ms = self.get_current_time_ms()
+        start_ms = self._start_stack_ms.pop()
+        delta_ms = int(end_ms - start_ms)
+        self.duration_in_ms = delta_ms
 
     @abc.abstractmethod
-    def get_current_time(self) -> float:
+    def get_current_time_ms(self) -> int:
+        """
+        Return the current time as integer milliseconds."""
+        raise NotImplementedError
+
+    def get_current_time(self) -> float:  # pragma: no cover - legacy API
         """
         Return the time in seconds since the epoch as a floating point number.
 
         See https://docs.python.org/3/library/time.html#time.time
         """
-        raise NotImplementedError
+        return self.get_current_time_ms() / 1000.0

--- a/src/importlinter/application/rendering.py
+++ b/src/importlinter/application/rendering.py
@@ -18,7 +18,7 @@ def render_report(report: Report) -> None:
         return
 
     if report.show_timings:
-        output.print(f"Building graph took {report.graph_building_duration}s.")
+        output.print(f"Building graph took {format_duration(report.graph_building_duration)}.")
         output.new_line()
 
     output.print_heading("Contracts", output.HEADING_LEVEL_TWO)
@@ -55,7 +55,7 @@ def render_contract_result_line(
 
     Args:
         ...
-        duration: The number of seconds the contract took to check (optional).
+        duration: The contract check duration in milliseconds (optional).
                   The duration will only be displayed if it is provided.
     """
     result_text = "KEPT" if contract_check.kept else "BROKEN"
@@ -66,7 +66,7 @@ def render_contract_result_line(
     output.print(result_text, color=color, newline=False)
     output.print(warning_text, color=output.COLORS[output.WARNING], newline=False)
     if duration is not None:
-        output.print(f" [{duration}s]", newline=False)
+        output.print(f" [{format_duration(duration)}]", newline=False)
     output.new_line()
 
 
@@ -121,3 +121,23 @@ def _render_broken_contracts_details(report: Report) -> None:
         output.print_heading(contract.name, output.HEADING_LEVEL_THREE, style=output.ERROR)
 
         contract.render_broken_contract(check)
+
+
+def format_duration(milliseconds: int) -> str:
+    """
+    Format a duration in milliseconds with units always in seconds:
+    - < 1s: to three decimal places, e.g. 0.127s
+    - < 10s: to one decimal place, e.g. 5.9s, 3.0s
+    - >= 10s: to 0 decimal places, e.g. 10s, 132s
+    """
+    try:
+        ms = int(milliseconds)
+    except Exception:
+        return f"{milliseconds}ms"
+
+    s = ms / 1000.0
+    if s < 1:
+        return f"{s:.3f}s"
+    if s < 10:
+        return f"{s:.1f}s"
+    return f"{int(round(s))}s"

--- a/src/importlinter/application/use_cases.py
+++ b/src/importlinter/application/use_cases.py
@@ -9,7 +9,7 @@ from ..domain.contract import Contract, InvalidContractOptions, registry
 from . import output
 from .app_config import settings
 from .ports.reporting import Report
-from .rendering import render_exception, render_report
+from .rendering import render_exception, render_report, format_duration
 from .sentinels import NotSupplied
 from .user_options import UserOptions
 
@@ -116,8 +116,9 @@ def create_report(
             exclude_type_checking_imports=exclude_type_checking_imports,
             verbose=verbose,
         )
-    graph_building_duration = timer.duration_in_s
-    output.verbose_print(verbose, f"Built graph in {graph_building_duration}s.")
+    graph_building_duration = timer.duration_in_ms
+
+    output.verbose_print(verbose, f"Built graph in {format_duration(graph_building_duration)}.")
 
     return _build_report(
         graph=graph,
@@ -199,9 +200,10 @@ def _build_report(
             # other contract checks.
             copy_of_graph = deepcopy(graph)
             check = contract.check(copy_of_graph, verbose=verbose)
-        report.add_contract_check(contract, check, duration=timer.duration_in_s)
+        duration_ms = timer.duration_in_ms
+        report.add_contract_check(contract, check, duration=duration_ms)
         if verbose:
-            rendering.render_contract_result_line(contract, check, duration=timer.duration_in_s)
+            rendering.render_contract_result_line(contract, check, duration=duration_ms)
 
     output.verbose_print(verbose, newline=True)
     return report

--- a/src/importlinter/contracts/forbidden.py
+++ b/src/importlinter/contracts/forbidden.py
@@ -5,6 +5,7 @@ from typing import Iterable, List, cast
 from grimp import ImportGraph
 
 from importlinter.application import contract_utils, output
+from importlinter.application import rendering
 from importlinter.application.contract_utils import AlertLevel
 from importlinter.configuration import settings
 from importlinter.domain import fields
@@ -126,9 +127,9 @@ class ForbiddenContract(Contract):
                 if verbose:
                     chain_count = len(subpackage_chain_data["chains"])
                     pluralized = "s" if chain_count != 1 else ""
+                    duration = rendering.format_duration(timer.duration_in_ms)
                     output.print(
-                        f"Found {chain_count} illegal chain{pluralized} "
-                        f"in {timer.duration_in_s}s.",
+                        f"Found {chain_count} illegal chain{pluralized} in {duration}.",
                     )
 
         # Sorting by upstream and downstream module ensures that the output is deterministic

--- a/tests/adapters/timing.py
+++ b/tests/adapters/timing.py
@@ -10,7 +10,7 @@ class FakeTimer(Timer):
 
     def __init__(self) -> None:
         super().__init__()
-        self._current_time = float(self.ARBITRARY_SECONDS_SINCE_EPOCH)
+        self._current_time_ms = int(self.ARBITRARY_SECONDS_SINCE_EPOCH * 1000)
         self._tick_duration = 1
         self._increment = 0
 
@@ -23,13 +23,13 @@ class FakeTimer(Timer):
         self._tick()
         super().__exit__(exc_type, exc_val, exc_tb)
 
-    def get_current_time(self) -> float:
-        return self._current_time
+    def get_current_time_ms(self) -> int:
+        return self._current_time_ms
 
     def setup(self, tick_duration: int, increment: int) -> None:
         self._tick_duration = tick_duration
         self._increment = increment
 
     def _tick(self) -> None:
-        self._current_time += self._tick_duration
+        self._current_time_ms += self._tick_duration * 1000
         self._tick_duration += self._increment

--- a/tests/unit/adapters/test_timing.py
+++ b/tests/unit/adapters/test_timing.py
@@ -11,7 +11,7 @@ class TestSystemClockTimer:
         with SystemClockTimer() as timer:
             time.sleep(some_seconds)
 
-        assert timer.duration_in_s >= some_seconds
+        assert timer.duration_in_ms >= some_seconds * 1000
 
     def test_nested(self):
         timer = SystemClockTimer()
@@ -22,12 +22,12 @@ class TestSystemClockTimer:
                 time.sleep(some_seconds)
                 with timer:
                     time.sleep(some_seconds)
-                inner_duration = timer.duration_in_s
-            middle_duration = timer.duration_in_s
-        outer_duration = timer.duration_in_s
+                inner_duration = timer.duration_in_ms
+            middle_duration = timer.duration_in_ms
+        outer_duration = timer.duration_in_ms
 
-        assert inner_duration >= some_seconds
-        assert middle_duration >= inner_duration + some_seconds
+        assert inner_duration >= some_seconds * 1000
+        assert middle_duration >= inner_duration + some_seconds * 1000
         assert outer_duration >= middle_duration
 
 
@@ -39,7 +39,7 @@ class TestFakeTimer:
         for expected in (10, 13, 16):
             with timer:
                 pass
-            assert timer.duration_in_s == expected
+            assert timer.duration_in_ms == expected * 1000
 
     def test_nested(self):
         timer = FakeTimer()
@@ -51,6 +51,6 @@ class TestFakeTimer:
             with timer:
                 with timer:
                     pass
-                assert timer.duration_in_s == 10
-            assert timer.duration_in_s == 23
-        assert timer.duration_in_s == 39
+                assert timer.duration_in_ms == 10 * 1000
+            assert timer.duration_in_ms == 23 * 1000
+        assert timer.duration_in_ms == 39 * 1000

--- a/tests/unit/application/test_rendering.py
+++ b/tests/unit/application/test_rendering.py
@@ -1,0 +1,22 @@
+import pytest
+
+from importlinter.application import rendering
+
+
+@pytest.mark.parametrize(
+    "milliseconds, expected",
+    [
+        (0, "0.000s"),
+        (1, "0.001s"),
+        (532, "0.532s"),
+        (999, "0.999s"),
+        (1000, "1.0s"),
+        (1234, "1.2s"),
+        (9950, "9.9s"),
+        (9999, "10.0s"),  # a bit ugly but not really worth fixing
+        (10000, "10s"),
+        (12400, "12s"),
+    ],
+)
+def test_format_duration(milliseconds, expected):
+    assert rendering.format_duration(milliseconds) == expected

--- a/tests/unit/application/test_use_cases.py
+++ b/tests/unit/application/test_use_cases.py
@@ -240,7 +240,7 @@ class TestCheckContractsAndPrintReport:
             Import Linter
             =============
 
-            Building graph took 5s.
+            Building graph took 5.0s.
 
             ---------
             Contracts
@@ -288,7 +288,7 @@ class TestCheckContractsAndPrintReport:
 
                 Verbose mode.
                 {{ graph building output }}
-                Built graph in 5s.
+                Built graph in 5.0s.
                 Checking Contract foo...
                 Hello from the noisy contract!
                 Contract foo KEPT [15s]


### PR DESCRIPTION
https://github.com/seddonym/import-linter/issues/281

The current behaviour of the --show-timings flag currently only shows things in seconds. Import Linter has got much faster, it would be helpful to show it in milliseconds now, where appropriate.

This commit will show the timings in seconds with up to 3 decimals if less than 10 seconds, and in milliseconds if less than 1 second.

With this commit the timer It's getting time from time.perf_counter_ns and then store internally in millis.