### PR TITLE
Feature special keyword module detection

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -28,3 +28,4 @@ Contributors
 * Felix Uhl - https://github.com/iFreilicht
 * Ilya S. (Tapeline) - https://github.com/Tapeline
 * Uberto Barbini - https://github.com/uberto
+* Adria Montoto - https://github.com/adriamontoto

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+latest
+------
+
+* Add support for special keywords in forbidden contracts: ``<third_party>`` to forbid all third-party packages and ``<stdlib>`` to forbid all Python standard library modules. These keywords can be combined with explicit module names for granular control.
+
 2.4 (2025-08-15)
 ----------------
 

--- a/docs/contract_types.rst
+++ b/docs/contract_types.rst
@@ -91,6 +91,39 @@ External packages may also be forbidden.
     ignore_imports =
         mypackage.business.config -> mypackage.legacy.settings
 
+.. code-block:: ini
+
+    [importlinter]
+    root_package = mypackage
+    include_external_packages = True
+
+    [importlinter:contract:forbid-stdlib]
+    name = Core modules should not use stdlib directly
+    type = forbidden
+    source_modules =
+        mypackage.core
+    forbidden_modules =
+        <stdlib>
+
+
+.. code-block:: ini
+
+    [importlinter]
+    root_package = mypackage
+    include_external_packages = True
+
+    [importlinter:contract:granular-forbidden]
+    name = Mixed granular restrictions
+    type = forbidden
+    source_modules =
+        mypackage.domain
+    forbidden_modules =
+        <third_party>
+        <stdlib>
+        mypackage.legacy
+    ignore_imports =
+        mypackage.domain.config -> mypackage.legacy.settings
+
 **Configuration options**
 
     - ``source_modules``:    A list of modules that should not import the forbidden modules. Supports :ref:`wildcards`.
@@ -98,9 +131,14 @@ External packages may also be forbidden.
       root level external packages (i.e. ``django``, but not ``django.db.models``). If external packages are included,
       the top level configuration must have ``include_external_packages = True``. Supports :ref:`wildcards`.
 
-      **Special keyword**: Use ``<third_party>`` to automatically forbid all third-party packages (external packages
-      that are not part of the Python standard library). This keyword can be combined with explicit module names.
+      **Special keywords**: Dynamic module detection using special keywords:
+      
+      - ``<third_party>``: All third-party packages (external packages that are not part of the Python standard library)
+      - ``<stdlib>``: All Python standard library modules
+      
+      These keywords can be combined with explicit module names and with each other.
       When using ``<third_party>``, you must set ``include_external_packages = True`` in the main configuration.
+      The ``<stdlib>`` keyword works regardless of this setting.
     - ``ignore_imports``: See :ref:`Shared options`.
     - ``unmatched_ignore_imports_alerting``: See :ref:`Shared options`.
     - ``allow_indirect_imports``: If ``True``, allow indirect imports to forbidden modules without interpreting them

--- a/docs/contract_types.rst
+++ b/docs/contract_types.rst
@@ -58,12 +58,49 @@ External packages may also be forbidden.
     ignore_imports =
         mypackage.one.green -> sqlalchemy
 
+.. code-block:: ini
+
+    [importlinter]
+    root_package = mypackage
+    include_external_packages = True
+
+    [importlinter:contract:forbid-third-party]
+    name = Domain layer must not import third-party libraries
+    type = forbidden
+    source_modules =
+        mypackage.domain
+    forbidden_modules =
+        <third_party>
+
+.. code-block:: ini
+
+    [importlinter]
+    root_package = mypackage
+    include_external_packages = True
+
+    [importlinter:contract:mixed-forbidden]
+    name = Business logic forbidden from third-party and legacy code
+    type = forbidden
+    source_modules =
+        mypackage.business
+        mypackage.core
+    forbidden_modules =
+        <third_party>
+        mypackage.legacy
+        mypackage.deprecated
+    ignore_imports =
+        mypackage.business.config -> mypackage.legacy.settings
+
 **Configuration options**
 
     - ``source_modules``:    A list of modules that should not import the forbidden modules. Supports :ref:`wildcards`.
     - ``forbidden_modules``: A list of modules that should not be imported by the source modules. These may include
       root level external packages (i.e. ``django``, but not ``django.db.models``). If external packages are included,
       the top level configuration must have ``include_external_packages = True``. Supports :ref:`wildcards`.
+
+      **Special keyword**: Use ``<third_party>`` to automatically forbid all third-party packages (external packages
+      that are not part of the Python standard library). This keyword can be combined with explicit module names.
+      When using ``<third_party>``, you must set ``include_external_packages = True`` in the main configuration.
     - ``ignore_imports``: See :ref:`Shared options`.
     - ``unmatched_ignore_imports_alerting``: See :ref:`Shared options`.
     - ``allow_indirect_imports``: If ``True``, allow indirect imports to forbidden modules without interpreting them

--- a/docs/toml.rst
+++ b/docs/toml.rst
@@ -43,6 +43,45 @@ Following, an example with a layered configuration:
         "low",
     ]
 
+Third-party dependencies
+------------------------
+
+The ``<third_party>`` keyword is also supported in TOML configuration:
+
+.. code-block:: toml
+
+    [tool.importlinter]
+    root_package = "mypackage"
+    include_external_packages = true
+
+    [[tool.importlinter.contracts]]
+    name = "Domain layer must not import third-party libraries"
+    type = "forbidden"
+    source_modules = ["mypackage.domain"]
+    forbidden_modules = ["<third_party>"]
+
+.. code-block:: toml
+
+    [tool.importlinter]
+    root_package = "mypackage" 
+    include_external_packages = true
+
+    [[tool.importlinter.contracts]]
+    name = "Core modules forbidden from third-party and legacy"
+    type = "forbidden"
+    source_modules = [
+        "mypackage.core",
+        "mypackage.business",
+    ]
+    forbidden_modules = [
+        "<third_party>",
+        "mypackage.legacy",
+        "mypackage.deprecated",
+    ]
+    ignore_imports = [
+        "mypackage.core.config -> mypackage.legacy.settings",
+    ]
+
 Contract ids
 ------------
 

--- a/docs/toml.rst
+++ b/docs/toml.rst
@@ -82,6 +82,35 @@ The ``<third_party>`` keyword is also supported in TOML configuration:
         "mypackage.core.config -> mypackage.legacy.settings",
     ]
 
+.. code-block:: toml
+
+    [tool.importlinter]
+    root_package = "mypackage"
+    include_external_packages = true
+
+    [[tool.importlinter.contracts]]
+    name = "Forbid stdlib usage"
+    type = "forbidden"
+    source_modules = ["mypackage.core"]
+    forbidden_modules = ["<stdlib>"]
+
+
+.. code-block:: toml
+
+    [tool.importlinter]
+    root_package = "mypackage"
+    include_external_packages = true
+
+    [[tool.importlinter.contracts]]
+    name = "Granular keyword control"
+    type = "forbidden"
+    source_modules = ["mypackage.domain"]
+    forbidden_modules = [
+        "<third_party>",
+        "<stdlib>",
+        "mypackage.legacy",
+    ]
+
 Contract ids
 ------------
 

--- a/src/importlinter/contracts/forbidden.py
+++ b/src/importlinter/contracts/forbidden.py
@@ -5,8 +5,7 @@ from typing import Iterable, List, cast
 
 from grimp import ImportGraph
 
-from importlinter.application import contract_utils, output
-from importlinter.application import rendering
+from importlinter.application import contract_utils, output, rendering
 from importlinter.application.contract_utils import AlertLevel
 from importlinter.configuration import settings
 from importlinter.domain import fields
@@ -26,8 +25,8 @@ class ForbiddenContract(Contract):
         - source_modules:    A set of Modules that should not import the forbidden modules.
         - forbidden_modules: A set of Modules that should not be imported by the source modules.
                              Supports special keywords for dynamic module detection:
-                             - "<third_party>": All third-party packages (external packages that are not
-                               part of the Python standard library)
+                             - "<third_party>": All third-party packages (external packages that are
+                             not part of the Python standard library)
                              - "<stdlib>": All Python standard library modules
                              These keywords can be combined with explicit module names.
         - ignore_imports:    A set of ImportExpressions. These imports will be ignored if the import
@@ -89,11 +88,11 @@ class ForbiddenContract(Contract):
             )
         )
 
-        forbidden_module_expressions = self.forbidden_modules  # type: ignore
+        forbidden_module_expressions = self.forbidden_modules
 
         expanded_expressions = set()
         special_keywords_found = []
-        for expr in forbidden_module_expressions:
+        for expr in forbidden_module_expressions:  # type: ignore
             expr_str = str(expr)
             if expr_str == "<third_party>":
                 special_keywords_found.append("third_party")
@@ -114,7 +113,7 @@ class ForbiddenContract(Contract):
                 output.verbose_print(
                     verbose,
                     f"Detected {len(third_party_modules)} third-party modules: "
-                    f"{', '.join(sorted(m.name for m in third_party_modules))}"
+                    f"{', '.join(sorted(m.name for m in third_party_modules))}",
                 )
 
                 if not third_party_modules:
@@ -122,7 +121,7 @@ class ForbiddenContract(Contract):
                         verbose,
                         "No third-party modules found in the import graph. "
                         "This may be expected if your project has no external dependencies, "
-                        "or if include_external_packages=False."
+                        "or if include_external_packages=False.",
                     )
 
             if "stdlib" in special_keywords_found:
@@ -132,20 +131,21 @@ class ForbiddenContract(Contract):
                 output.verbose_print(
                     verbose,
                     f"Detected {len(stdlib_modules)} stdlib modules: "
-                    f"{', '.join(sorted(m.name for m in stdlib_modules))}"
+                    f"{', '.join(sorted(m.name for m in stdlib_modules))}",
                 )
 
                 if not stdlib_modules:
                     output.verbose_print(
                         verbose,
                         "No stdlib modules found in the import graph. "
-                        "This may be expected on Python < 3.10 or if no stdlib modules are imported."
+                        "This may be expected on Python < 3.10 or if no stdlib modules are"
+                        " imported.",
                     )
 
             for _, modules in keyword_modules.items():
                 for module in modules:
                     expanded_expressions.add(ModuleExpression(module.name))
-            
+
             forbidden_modules = list(
                 module_expressions_to_modules(
                     graph,
@@ -156,7 +156,7 @@ class ForbiddenContract(Contract):
             forbidden_modules = list(
                 module_expressions_to_modules(
                     graph,
-                    forbidden_module_expressions,
+                    forbidden_module_expressions,  # type: ignore
                 )
             )
 
@@ -339,8 +339,7 @@ class ForbiddenContract(Contract):
         all_modules = [Module(name) for name in graph.modules]
 
         return [
-            module for module in all_modules
-            if module.root_package_name in stdlib_module_names
+            module for module in all_modules if module.root_package_name in stdlib_module_names
         ]
 
     def _get_third_party_modules(self, graph: ImportGraph) -> List[Module]:
@@ -355,7 +354,8 @@ class ForbiddenContract(Contract):
             List of third-party modules found in the graph.
 
         Raises:
-            ValueError: If third-party detection is requested but external packages are not included.
+            ValueError: If third-party detection is requested but external packages are not
+            included.
         """
         if not self._graph_was_built_with_externals():
             raise ValueError(
@@ -381,11 +381,13 @@ class ForbiddenContract(Contract):
             )
 
         external_modules = [
-            module for module in all_modules
+            module
+            for module in all_modules
             if not any(module.is_in_package(root_package) for root_package in root_packages)
         ]
 
         return [
-            module for module in external_modules
+            module
+            for module in external_modules
             if module.root_package_name not in stdlib_module_names
         ]

--- a/tests/unit/contracts/test_forbidden.py
+++ b/tests/unit/contracts/test_forbidden.py
@@ -3,7 +3,6 @@ from typing import Tuple, List, Dict
 import pytest
 from grimp.adaptors.graph import ImportGraph
 
-from importlinter.application import output
 from importlinter.configuration import settings
 from importlinter.contracts.forbidden import ForbiddenContract
 from importlinter.domain.contract import ContractCheck
@@ -304,7 +303,7 @@ class TestForbiddenContract:
         assert check.metadata["invalid_chains"] == [
             {
                 "upstream_module": "requests",
-                "downstream_module": "mypackage.one", 
+                "downstream_module": "mypackage.one",
                 "chains": [
                     [
                         {
@@ -313,7 +312,7 @@ class TestForbiddenContract:
                             "line_numbers": (1,),
                         }
                     ]
-                ]
+                ],
             }
         ]
 
@@ -355,7 +354,7 @@ class TestForbiddenContract:
 
         graph.add_module("json", is_squashed=True)
         graph.add_import(
-            importer="mypackage.one", 
+            importer="mypackage.one",
             imported="json",
             line_number=1,
             line_contents="import json",
@@ -363,7 +362,7 @@ class TestForbiddenContract:
 
         graph.add_import(
             importer="mypackage.one",
-            imported="requests", 
+            imported="requests",
             line_number=2,
             line_contents="import requests",
         )
@@ -394,7 +393,7 @@ class TestForbiddenContract:
             match=(
                 "Cannot use '<third_party>' in forbidden_modules when "
                 "include_external_packages=False"
-            )
+            ),
         ):
             contract.check(graph=graph, verbose=False)
 
@@ -439,7 +438,7 @@ class TestForbiddenContract:
         )
 
         contract.check(graph=graph, verbose=True)
-        
+
         output_text = fake_printer._buffer
         assert "Detected 0 third-party modules" in output_text
         assert "No third-party modules found" in output_text
@@ -518,7 +517,7 @@ class TestForbiddenContract:
 
         with pytest.raises(
             ValueError,
-            match="The top level configuration must have include_external_packages=True"
+            match="The top level configuration must have include_external_packages=True",
         ):
             contract.check(graph=graph, verbose=False)
 


### PR DESCRIPTION
This PR implements special keywords in forbidden modules to provide dynamic module detection capabilities, clossing [#278](https://github.com/seddonym/import-linter/issues/278).


  ✨ New Features

  Special Keywords Added:
  - `<third_party>`: Automatically detects and forbids all third-party packages (external packages not in the Python standard library).
  - `<stdlib>`: Automatically detects and forbids all Python standard library modules.
  
📝 Configuration Examples
```toml
  [[tool.importlinter.contracts]]
  name = 'Domain layer must not depend on third-party libraries'
  type = 'forbidden'
  source_modules = ['myproject.*.domain']
  forbidden_modules = ['<third_party>', '<stdlib>', 'myproject.deprecated']
  ignore_imports = [
      'myproject.** -> enum',
      'myproject.** -> typing',
      'myproject.** -> abc',
  ]
```