### PR TITLE
Remove mention of protected modules being able to import each other

### DIFF
--- a/docs/contract_types.rst
+++ b/docs/contract_types.rst
@@ -120,7 +120,7 @@ then no module other than ``green`` (and its descendants) will be allowed to imp
 
 **Configuration options**
 
-    - ``protected_modules``: The modules that must not be imported except by the list of importers, and by each other. Supports :ref:`wildcards`.
+    - ``protected_modules``: The modules that must not be imported except by the list of importers, and those in the same package. Supports :ref:`wildcards`.
     - ``allowed_importers``: The only modules allowed to import the target modules. Supports :ref:`wildcards`.
     - ``ignore_imports``:  See :ref:`Shared options`.
     - ``unmatched_ignore_imports_alerting``: See :ref:`Shared options`.


### PR DESCRIPTION
This is an artefact from previous development version.
Now the only implicitly allowed imports are the one in the same package