### PR TITLE
Correct protected contract documentation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+latest
+------
+
+* Correct documentation that incorrectly stated that protected modules
+  are allowed to import each other.
+
 2.5 (2025-09-15)
 ----------------
 

--- a/docs/contract_types.rst
+++ b/docs/contract_types.rst
@@ -90,20 +90,20 @@ then no module other than ``green`` (and its descendants) will be allowed to imp
     [importlinter]
     root_package = mypackage
 
-    [importlinter:contract:my-simple-protected-contract]
-    name = My simple protected contract
+    [importlinter:contract:simple-protected-contract]
+    name = Simple protected contract
     type = protected
     protected_modules =
-        mypackage.one
+        mypackage.protected
+        mypackage.also_protected
     allowed_importers =
-        mypackage.two
-        mypackage.three.blue
+        mypackage.allowed
+        mypackage.also_allowed
 
 .. code-block:: ini
 
     [importlinter]
     root_package = mypackage
-
 
     [importlinter:contract:models-can-only-be-imported-by-colors]
     name = Models can only be imported by colors direct descendant
@@ -115,12 +115,15 @@ then no module other than ``green`` (and its descendants) will be allowed to imp
     ignore_imports =
         mypackage.one.green -> mypackage.one.models
         mypackage.colors.red.foo -> mypackage.three.models
-    unmatched_ignore_imports_alerting = warn
     as_packages = False
 
 **Configuration options**
 
-    - ``protected_modules``: The modules that must not be imported except by the list of importers, and by each other. Supports :ref:`wildcards`.
+    - ``protected_modules``: The modules that must not be imported except by the list of allowed importers.
+      If ``as_packages`` is ``True``, descendants of a protected module are also allowed to import each other.
+      For example, in the *Simple protected contract* above, ``mypackage.protected.green`` is allowed to import
+      ``mypackage.protected.blue``, but ``mypackage.red`` and ``mypackage.also_protected.yellow`` are not.
+      Supports :ref:`wildcards`.
     - ``allowed_importers``: The only modules allowed to import the target modules. Supports :ref:`wildcards`.
     - ``ignore_imports``:  See :ref:`Shared options`.
     - ``unmatched_ignore_imports_alerting``: See :ref:`Shared options`.

--- a/src/importlinter/contracts/protected.py
+++ b/src/importlinter/contracts/protected.py
@@ -13,8 +13,10 @@ class ProtectedContract(Contract):
     modules.
 
     Configuration options:
-        - protected_modules:    The modules that must not be imported except by allowed_importers,
-                                and by each other.
+        - protected_modules:    The modules that must not be imported except by allowed_importers.
+                                The modules that must not be imported except by the list of allowed
+                                importers. If `as_packages` is True, descendants of a protected
+                                module are also allowed to import each other.
         - allowed_importers:    The only modules allowed to import the protected modules.
         - ignore_imports:       A set of ImportExpressions. These imports will be ignored if the
                                 import would cause a contract to be broken, adding it to the set

--- a/tests/unit/contracts/test_protected.py
+++ b/tests/unit/contracts/test_protected.py
@@ -24,6 +24,8 @@ class TestProtectedContract:
             "mypackage.foo.protected.models.one",
             "mypackage.foo.protected.models.two",
             "mypackage.foo.protected.other_models",
+            "mypackage.other_protected",
+            "mypackage.other_protected.blue",
             "mypackage.foo.sibling",
             "mypackage.foo.sibling.models",
         ):
@@ -140,7 +142,7 @@ class TestProtectedContract:
                     "line_contents": "print",
                 },
                 True,
-                "Modules inside protected package can import each others",
+                "Modules inside protected package can import each other",
             ),
             (
                 {
@@ -160,7 +162,17 @@ class TestProtectedContract:
                     "line_contents": "print",
                 },
                 False,
-                "Other modules are not allowed to protected ones",
+                "Modules not mentioned in the contract are not allowed to import protected ones",
+            ),
+            (
+                {
+                    "importer": "mypackage.other_protected.blue",
+                    "imported": "mypackage.foo.protected.models",
+                    "line_number": 3,
+                    "line_contents": "print",
+                },
+                False,
+                "Other protected modules are not allowed to import protected ones",
             ),
             (
                 {
@@ -208,8 +220,8 @@ class TestProtectedContract:
                 "root_packages": ["mypackage"],
             },
             contract_options={
-                "protected_modules": ("mypackage.foo.protected"),
-                "allowed_importers": ("mypackage.bar.allowed"),
+                "protected_modules": ["mypackage.foo.protected", "mypackage.other_protected"],
+                "allowed_importers": ["mypackage.bar.allowed"],
                 "as_packages": "True",
             },
         )

--- a/tests/unit/contracts/test_protected.py
+++ b/tests/unit/contracts/test_protected.py
@@ -229,6 +229,27 @@ class TestProtectedContract:
         contract_check = contract.check(graph=graph, verbose=False)
         assert contract_check.kept == contract_kept, description
 
+    def test_can_add_protected_modules_to_allowed_importers(self):
+        graph = self._build_default_graph()
+        graph.add_import(
+            importer="mypackage.other_protected.blue",
+            imported="mypackage.foo.protected.models",
+        )
+        contract = ProtectedContract(
+            name="Protected contract",
+            session_options={
+                "root_packages": ["mypackage"],
+            },
+            contract_options={
+                "protected_modules": ["mypackage.foo.protected", "mypackage.other_protected"],
+                "allowed_importers": ["mypackage.other_protected"],
+            },
+        )
+
+        contract_check = contract.check(graph=graph, verbose=False)
+
+        assert contract_check.kept is True
+
     @pytest.mark.parametrize(
         "import_details,contract_kept,description",
         [


### PR DESCRIPTION
The docs currently state that `protected_modules` are "the modules that must not be imported except by the list of importers, and by each other."

But this is not true - this PR corrects them.

<img width="766" height="783" alt="image" src="https://github.com/user-attachments/assets/2fea4ed3-fb22-489a-9df2-34265bcd7ef5" />
