### PR TITLE
Correct CI error running lint instead of test

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,8 +33,8 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Lint
-        run: just lint
+      - name: Test
+        run: just test
 
   lint:
     name: Lint under ${{ matrix.python-version }}


### PR DESCRIPTION
Prior to this we were accidentally running the linter but not the tests in CI.
