### PR TITLE
Feat/source roots option

### DIFF
--- a/docs/authors.md
+++ b/docs/authors.md
@@ -18,6 +18,7 @@
 * [Jan Bielecki](https://github.com/K4liber)
 * [Kai Mueller](https://github.com/kasium)
 * [Łukasz Skarżyński](https://github.com/skarzi)
+* [Mark Todisco](https://github.com/marktodisco)
 * [Matthew Gamble](https://github.com/mwgamble)
 * [Neil Williams](https://github.com/spladug)
 * [Nicholas Bunn](https://github.com/NicholasBunn)

--- a/docs/get_started/configure.md
+++ b/docs/get_started/configure.md
@@ -19,6 +19,8 @@ If not specified over the command line, Import Linter will look in the current d
     # Optional:
     include_external_packages = True
     exclude_type_checking_imports = True
+    source_roots=
+        src
     ```
 
 === "TOML"
@@ -28,6 +30,7 @@ If not specified over the command line, Import Linter will look in the current d
     # Optional:
     include_external_packages = true
     exclude_type_checking_imports = true
+    source_roots = [ "src" ]
     ```
 
 Or, with multiple root packages:
@@ -41,6 +44,9 @@ Or, with multiple root packages:
     # Optional:
     include_external_packages = True
     exclude_type_checking_imports = True
+    source_roots=
+        packages/package-one/src
+        packages/package-two/src
     ```
 
 === "TOML"
@@ -50,6 +56,7 @@ Or, with multiple root packages:
     # Optional:
     include_external_packages = true
     exclude_type_checking_imports = true
+    source_roots = [ "packages/package-one/src", "packages/package-two/src" ]
     ```
 
 **Options:**
@@ -75,6 +82,12 @@ Or, with multiple root packages:
   Whether to exclude imports made in type checking guards. If this is `True`, any import made under an
   `if TYPE_CHECKING:` statement will not be added to the graph.
   For more information, see [the Grimp build_graph documentation](https://grimp.readthedocs.io/en/latest/usage.html#grimp.build_graph). (Optional.)
+- `source_roots`:
+  One or more directories added to the Python import search path when building the
+  import graph. Use this when your `root_packages` live in a non-root location (e.g., a
+  src/ layout or a multi-package monorepo). Paths can be absolute or relative to the
+  config file directory. Relative paths are resolved before being added to the path.
+  (Optional.)
 
 ## Contracts
 

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -1,5 +1,9 @@
 # Release notes
 
+## 2.10 (2025-12-20)
+
+* Add support for `source_roots` configuration option.
+
 ## 2.9 (2025-12-11)
 
 * Support passing namespaces as root packages, not just portions.

--- a/src/importlinter/application/use_cases.py
+++ b/src/importlinter/application/use_cases.py
@@ -1,5 +1,7 @@
 import importlib
 from copy import copy, deepcopy
+import os
+import sys
 from typing import Any
 import contextlib
 from grimp import ImportGraph
@@ -59,6 +61,7 @@ def lint_imports(
     output.verbose_print(verbose, "Verbose mode.")
     try:
         user_options = read_user_options(config_filename=config_filename)
+        _modify_path(user_options)
         _register_contract_types(user_options)
         report = create_report(user_options, limit_to_contracts, cache_dir, show_timings, verbose)
     except Exception as e:
@@ -233,6 +236,13 @@ def _build_report(
 
     output.verbose_print(verbose, newline=True)
     return report
+
+
+def _modify_path(user_options: UserOptions) -> None:
+    source_roots = user_options.session_options.get("source_roots", [])
+    # Add current directory to the path, as this doesn't happen automatically.
+    # Place the source roots after the current directory.
+    sys.path = [os.getcwd(), *source_roots, *sys.path]
 
 
 def _get_contract_checking_progress(verbose: bool) -> Progress:

--- a/src/importlinter/cli.py
+++ b/src/importlinter/cli.py
@@ -1,4 +1,3 @@
-import os
 import sys
 from logging import config as logging_config
 
@@ -88,9 +87,6 @@ def lint_imports(
     Returns:
         EXIT_STATUS_SUCCESS or EXIT_STATUS_ERROR.
     """
-    # Add current directory to the path, as this doesn't happen automatically.
-    sys.path.insert(0, os.getcwd())
-
     _configure_logging(verbose)
 
     combined_cache_dir = _combine_caching_arguments(cache_dir, no_cache)


### PR DESCRIPTION
This pull request resolves #274 by introducing support for a new `source_roots` configuration option, allowing users to specify additional directories to be added to the Python import search path. This is particularly useful for projects using a `src/` layout or monorepos with multiple package roots. The changes include updates to documentation, release notes, logic, and tests to ensure correct handling of the new option.

- [x] Add tests for the change.
- [x] Add any appropriate documentation.
- [x] Run `just check`. (see note below)
- [x] Add a summary of changes to `docs/release_notes.md`.
- [x] Add your name to `docs/authors.md` (in alphabetical order).

**Note**: The `just check` command as currently configured requests Python 3.9 which contradicts `requires-python = ">=3.10"` in `pyproject.toml`. I ran `just check` (excluding `just test-all`), and manually executed only the relevant tests with `for v in 10 11 12 13 14; do just "test-3-$v"; done`. Also, there is an issue with parallel test execution because it consistently failed on my machine.