### PR TITLE
fix: seed initial history state to prevent back button breaking

### DIFF
--- a/docs/authors.md
+++ b/docs/authors.md
@@ -20,6 +20,7 @@
 * [Lincoln Puzey](https://github.com/LincolnPuzey)
 * [Łukasz Skarżyński](https://github.com/skarzi)
 * [Matthew Gamble](https://github.com/mwgamble)
+* [Nazli Ander](https://github.com/nazliander)
 * [Neil Williams](https://github.com/spladug)
 * [Nicholas Bunn](https://github.com/NicholasBunn)
 * [Nick Pope](https://github.com/ngnpope)
@@ -27,4 +28,3 @@
 * [Petter Friberg](https://github.com/flaeppe)
 * [piglei](https://github.com/piglei)
 * [Uberto Barbini](https://github.com/uberto)
-

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -1,5 +1,9 @@
 # Release notes
 
+## latest
+
+* Bugfix: fix back button navigation in explore command. 
+
 ## 2.10 (2026-02-06)
 
 * Add `import-linter` group command, with `import-linter lint` alias.

--- a/src/importlinter/ui/static/explorer.js
+++ b/src/importlinter/ui/static/explorer.js
@@ -370,4 +370,5 @@ initViz().then(() => {
     const moduleFromUrl = getModuleFromUrl();
     const initialModule = moduleFromUrl || document.querySelector('#breadcrumb .current')?.textContent;
     loadGraph(initialModule, false);
+    history.replaceState({ module: initialModule }, '');
 });


### PR DESCRIPTION
This is a pretty small bug, which is not so significant on developer experience. I saw it is a one liner, so proposing a fix.

How to re-produce:

- Pop the explore screen
- Drill down by double clicking on a module
- Press back button on the browser

This results in a request to `/api/graph/null` and `ValueError: Could not find package 'null' in your Python path.`

The fix is to store the currently displayed module in the browser history on page load. So the browser can restore.

- [x] Add tests for the change.
- [x] Add any appropriate documentation.
- [X] Run `just check`.
- [x] Add a summary of changes to `docs/release_notes.md`.
- [x] Add your name to `docs/authors.md` (in alphabetical order).

