### PR TITLE
add depth option in CLI and web UI

### DIFF
--- a/src/importlinter/cli.py
+++ b/src/importlinter/cli.py
@@ -106,7 +106,15 @@ def explore(module_name: str) -> None:
     is_flag=True,
     help="Mark dependencies that, if removed, would make the graph acyclic.",
 )
-def drawgraph(module_name: str, show_import_totals: bool, show_cycle_breakers: bool) -> None:
+@click.option(
+    "--depth",
+    type=int,
+    default=1,
+    help="Depth of submodules to include in the graph (default: 1 for direct children).",
+)
+def drawgraph(
+    module_name: str, show_import_totals: bool, show_cycle_breakers: bool, depth: int
+) -> None:
     """Output a DOT format graph of a module's dependencies to stdout.
 
     MODULE_NAME is the importable Python module to graph (e.g. 'django.db.models').
@@ -128,7 +136,7 @@ def drawgraph(module_name: str, show_import_totals: bool, show_cycle_breakers: b
 
     grimp_graph = grimp.build_graph(top_level_package)
     dot = use_cases.build_dot_graph(
-        grimp_graph, module_name, show_import_totals, show_cycle_breakers
+        grimp_graph, module_name, show_import_totals, show_cycle_breakers, depth=depth
     )
     click.echo(dot.render(), nl=False)
 

--- a/src/importlinter/domain/dotfile.py
+++ b/src/importlinter/domain/dotfile.py
@@ -9,7 +9,10 @@ class Edge:
     emphasized: bool = False
 
     def __str__(self) -> str:
-        return f'"{DotGraph.render_module(self.source)}" ->  "{DotGraph.render_module(self.destination)}"{self._render_attrs()}'
+        return self.render(base_module="")
+
+    def render(self, base_module: str) -> str:
+        return f'"{DotGraph.render_module(self.source, base_module)}" ->  "{DotGraph.render_module(self.destination, base_module)}"{self._render_attrs()}'
 
     def _render_attrs(self) -> str:
         attrs: dict[str, str] = {}
@@ -34,6 +37,7 @@ class DotGraph:
 
     title: str
     concentrate: bool = True
+    depth: int = 1
     nodes: set[str] = field(default_factory=set)
     edges: set[Edge] = field(default_factory=set)
 
@@ -50,13 +54,18 @@ class DotGraph:
         if self.concentrate:
             lines.append(f"{indent}concentrate=true")
         for node in sorted(self.nodes):
-            lines.append(f'{indent}"{self.render_module(node)}"')
+            lines.append(f'{indent}"{self.render_module(node, self.title)}"')
         for edge in sorted(self.edges):
-            lines.append(f"{indent}{edge}")
+            lines.append(f"{indent}{edge.render(self.title)}")
         lines.append("}")
         return "\n".join(lines) + "\n"
 
     @staticmethod
-    def render_module(module: str) -> str:
-        # Render as relative module.
-        return f".{module.split('.')[-1]}"
+    def render_module(module: str, base_module: str = "") -> str:
+        # Render as relative module by stripping the base module prefix.
+        if base_module and module.startswith(base_module + "."):
+            relative = module[len(base_module) :]
+            return relative  # Already starts with "."
+        else:
+            # Fallback: show as relative with just the last component.
+            return f".{module.split('.')[-1]}"

--- a/src/importlinter/ui/explorer.py
+++ b/src/importlinter/ui/explorer.py
@@ -36,12 +36,15 @@ def generate_dot(
     module: str,
     show_import_totals: bool,
     show_cycle_breakers: bool,
+    depth: int = 1,
 ) -> ModuleDot:
     logger.info(f"Building graph for module '{module}'...")
     top_level_package = module.split(".")[0]
     grimp_graph = _get_grimp_graph(cache, top_level_package)
 
-    dot_graph = build_dot_graph(grimp_graph, module, show_import_totals, show_cycle_breakers)
+    dot_graph = build_dot_graph(
+        grimp_graph, module, show_import_totals, show_cycle_breakers, depth=depth
+    )
     dot_string = dot_graph.render()
 
     child_packages = _get_child_packages(grimp_graph, module)

--- a/src/importlinter/ui/server.py
+++ b/src/importlinter/ui/server.py
@@ -103,10 +103,15 @@ def create_app(
         module: str,
         show_import_totals: bool = False,
         show_cycle_breakers: bool = False,
+        depth: int = 1,
     ) -> GraphResponse | ErrorResponse:
         try:
             graph_data = generate_dot(
-                request.app.state.grimp_cache, module, show_import_totals, show_cycle_breakers
+                request.app.state.grimp_cache,
+                module,
+                show_import_totals,
+                show_cycle_breakers,
+                depth=depth,
             )
             return cast(GraphResponse, dataclasses.asdict(graph_data))
         except Exception as e:

--- a/src/importlinter/ui/static/explorer.js
+++ b/src/importlinter/ui/static/explorer.js
@@ -14,6 +14,7 @@ let currentPackages = [];
 // Settings state
 let showImportTotals = false;
 let showCycleBreakers = false;
+let depth = 1;
 
 // Client-side cache for rendered graphs
 const graphCache = new Map();
@@ -31,6 +32,9 @@ function buildApiUrl(moduleName) {
     if (showCycleBreakers) {
         params.push('show_cycle_breakers=true');
     }
+    if (depth !== 1) {
+        params.push(`depth=${depth}`);
+    }
     if (params.length) {
         url += '?' + params.join('&');
     }
@@ -38,12 +42,13 @@ function buildApiUrl(moduleName) {
 }
 
 function buildCacheKey(moduleName) {
-    return `${moduleName}|${showImportTotals}|${showCycleBreakers}`;
+    return `${moduleName}|${showImportTotals}|${showCycleBreakers}|${depth}`;
 }
 
 function onSettingsChange() {
     showImportTotals = document.getElementById('toggle-import-totals').checked;
     showCycleBreakers = document.getElementById('toggle-cycle-breakers').checked;
+    depth = parseInt(document.getElementById('depth-input').value, 10) || 1;
     loadGraph(currentModule, false);
 }
 

--- a/src/importlinter/ui/static/index.html
+++ b/src/importlinter/ui/static/index.html
@@ -61,6 +61,13 @@
                         </div>
                         <div class="toggle-help">Nominate a minimal set of dependencies which, if removed, would make the import graph acyclic. These dependencies are shown as dashed lines.</div>
                     </div>
+                    <div class="toggle-item">
+                        <div class="toggle-row">
+                            <label class="toggle-label" for="depth-input">Depth</label>
+                            <input type="number" id="depth-input" min="1" max="5" value="1" onchange="onSettingsChange()" style="width: 3.5em; margin-left: auto; padding: 4px 6px; border: 1px solid var(--border); border-radius: 4px; background: var(--bg); color: var(--text); font-size: 0.9em;">
+                        </div>
+                        <div class="toggle-help">Number of submodule levels to include in the graph (1 = direct children only).</div>
+                    </div>
                 </div>
             </div>
         </div>

--- a/tests/unit/domain/test_dotfile.py
+++ b/tests/unit/domain/test_dotfile.py
@@ -31,3 +31,49 @@ class TestDotGraph:
                 ".bar" ->  ".baz"
             }
         """)
+
+    def test_render_with_depth_2(self):
+        dot = DotGraph(title="mypackage.foo", depth=2)
+        dot.add_node("mypackage.foo.blue")
+        dot.add_node("mypackage.foo.green")
+        dot.add_node("mypackage.foo.blue.alpha")
+        dot.add_edge(Edge(source="mypackage.foo.blue.alpha", destination="mypackage.foo.green"))
+
+        rendered = dot.render()
+
+        assert rendered == dedent("""\
+            digraph {
+                node [fontname=helvetica]
+                concentrate=true
+                ".blue"
+                ".blue.alpha"
+                ".green"
+                ".blue.alpha" ->  ".green"
+            }
+        """)
+
+
+class TestRenderModule:
+    def test_render_module_with_base_module(self):
+        assert DotGraph.render_module("mypackage.foo.bar", "mypackage.foo") == ".bar"
+
+    def test_render_module_with_nested_base_module(self):
+        assert DotGraph.render_module("mypackage.foo.blue.alpha", "mypackage.foo") == ".blue.alpha"
+
+    def test_render_module_without_base_module(self):
+        assert DotGraph.render_module("mypackage.foo.bar") == ".bar"
+
+    def test_render_module_fallback_when_no_prefix_match(self):
+        assert DotGraph.render_module("other.bar", "mypackage.foo") == ".bar"
+
+
+class TestEdge:
+    def test_render_with_base_module(self):
+        edge = Edge(source="mypackage.foo.bar", destination="mypackage.foo.baz")
+        rendered = edge.render("mypackage.foo")
+        assert rendered == '".bar" ->  ".baz"'
+
+    def test_render_with_depth_2_modules(self):
+        edge = Edge(source="mypackage.foo.blue.alpha", destination="mypackage.foo.green")
+        rendered = edge.render("mypackage.foo")
+        assert rendered == '".blue.alpha" ->  ".green"'


### PR DESCRIPTION
See initial discussion here: https://github.com/seddonym/impulse/issues/35

=> I ported the first feature "--depth" to "import-linter" in the CLI / web UI

Warning: this is mostly vibe-coded

but IMHO, in the web UI, this is really great (and it can be better with the next features of the initial discussion)

<img width="1744" height="1034" alt="Screenshot (60)" src="https://github.com/user-attachments/assets/69cd60c0-9565-42e7-8cf1-650a1fb50051" />

[x] Add tests for the change.
[x] Add any appropriate documentation.
[x] Run `just check`.
[ ] Add a summary of changes to `docs/release_notes.md`.
[ ] Add your name to `docs/authors.md` (in alphabetical order).

=> @seddonym, before going further, are you ok with the idea?

EDIT: also added the option "hide unlinked node" in this branch if you want to play with it
https://github.com/fabien-marty/import-linter/tree/add-hide-unliked
(yes, there is a typo in the branch name)