### PR TITLE
Tweak missing ui dependencies message

### DIFF
--- a/src/importlinter/cli.py
+++ b/src/importlinter/cli.py
@@ -97,8 +97,8 @@ def explore(module_name: str) -> None:
     except ImportError:
         console.print("[red]This command requires the [bold]ui[/bold] extra to be installed.")
         console.print(
-            "[dim]:point_right: Install it by using [bold]import-linter\\[ui][/bold] during installation,\n"
-            "e.g. [bold]pip install import-linter\\[ui][/bold]."
+            "[dim]:point_right: Install it by using [cyan1]import-linter\\[ui][/cyan1] during installation,\n"
+            "e.g. [bold cyan1]pip install 'import-linter\\[ui]'[/bold cyan1]."
         )
         sys.exit(1)
     rendering.print_title()

--- a/tests/functional/test_cli_without_ui_dependencies.py
+++ b/tests/functional/test_cli_without_ui_dependencies.py
@@ -14,7 +14,7 @@ class TestCliWithoutUiDependencies:
     def test_explore_exits_with_error_and_helpful_message(self):
         result = CliRunner().invoke(importlinter.cli.import_linter, ["explore", "somepackage"])
         assert result.exit_code == 1
-        assert "pip install import-linter[ui]" in result.output
+        assert "pip install 'import-linter[ui]'" in result.output
 
     def test_lint_help_exits_successfully(self):
         result = CliRunner().invoke(importlinter.cli.import_linter, ["lint", "--help"])


### PR DESCRIPTION
In some shells, square brackets are interpreted as globbing characters. Without quotes, the shell may attempts to match a file named `import-linteru` or `import-linteri`.

This also tweaks the text styles used to better delineate the command.

<img width="862" height="147" alt="image" src="https://github.com/user-attachments/assets/84e4631b-0468-4970-958a-d140ab5446f8" />
