### PR TITLE
feat: add --version flag to lint-imports and import-linter commands

### DIFF
--- a/docs/authors.md
+++ b/docs/authors.md
@@ -20,6 +20,7 @@
 * [Kai Mueller](https://github.com/kasium)
 * [Lincoln Puzey](https://github.com/LincolnPuzey)
 * [Łukasz Skarżyński](https://github.com/skarzi)
+* [Matt Wang](https://github.com/mattwang44)
 * [Matthew Gamble](https://github.com/mwgamble)
 * [Nazli Ander](https://github.com/nazliander)
 * [Neil Williams](https://github.com/spladug)

--- a/docs/get_started/run.md
+++ b/docs/get_started/run.md
@@ -28,6 +28,8 @@ lint-imports
   Display the times taken to build the graph and check each contract. (Optional.)
 - `--verbose`:
   Noisily output progress as it goes along. (Optional.)
+- `--version`:
+  Display the version of Import Linter and exit. (Optional.)
 
 #### Default usage
 

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -2,6 +2,7 @@
 
 ## latest
 
+* Add `--version` flag to `lint-imports` and `import-linter` commands.
 * Make `fastapi` and `uvicorn` optional via the `ui` extra (`pip install import-linter[ui]`).
 * Bugfix: fix back button navigation in explore command. 
 

--- a/src/importlinter/cli.py
+++ b/src/importlinter/cli.py
@@ -5,6 +5,7 @@ from logging import config as logging_config
 import click
 import grimp
 
+from importlinter import __version__
 from importlinter.application.sentinels import NotSupplied
 
 from . import configuration
@@ -64,6 +65,7 @@ def _run_check(
 
 
 @click.command()
+@click.version_option(version=__version__)
 @check_options
 def lint_imports_command(**kwargs) -> None:
     """Check that a project adheres to a set of contracts."""
@@ -71,6 +73,7 @@ def lint_imports_command(**kwargs) -> None:
 
 
 @click.group(invoke_without_command=True)
+@click.version_option(version=__version__)
 @click.pass_context
 def import_linter(ctx: click.Context) -> None:
     if ctx.invoked_subcommand is None:

--- a/src/importlinter/cli.py
+++ b/src/importlinter/cli.py
@@ -65,7 +65,7 @@ def _run_check(
 
 
 @click.command()
-@click.version_option(version=__version__)
+@click.version_option(version=__version__, message="import-linter %(version)s")
 @check_options
 def lint_imports_command(**kwargs) -> None:
     """Check that a project adheres to a set of contracts."""
@@ -73,7 +73,7 @@ def lint_imports_command(**kwargs) -> None:
 
 
 @click.group(invoke_without_command=True)
-@click.version_option(version=__version__)
+@click.version_option(version=__version__, message="import-linter %(version)s")
 @click.pass_context
 def import_linter(ctx: click.Context) -> None:
     if ctx.invoked_subcommand is None:

--- a/tests/functional/test_lint_imports.py
+++ b/tests/functional/test_lint_imports.py
@@ -4,8 +4,9 @@ import sys
 from pathlib import Path
 from unittest.mock import patch
 import pytest
+from click.testing import CliRunner
 
-from importlinter import cli
+from importlinter import __version__, cli
 from importlinter.application import output
 import io
 
@@ -119,6 +120,14 @@ def test_logging_configuration_respects_verbose_flag(verbose, capsys):
 
     # N.B. "Wrote data cache file" is logged by Grimp.
     assert ("Wrote data cache file" in captured.out) == verbose
+
+
+@pytest.mark.parametrize("command", (cli.lint_imports_command, cli.import_linter))
+def test_versions(command):
+    runner = CliRunner()
+    result = runner.invoke(command, ["--version"])
+
+    assert result.output == f"import-linter {__version__}\n"
 
 
 def test_windows_terminal_encoding_smoke_test():


### PR DESCRIPTION
Adds `click.version_option` to both CLI entry points so users can check the installed version.
resolve #339 


[x] Add tests for the change.
[x] Add any appropriate documentation.
[x] Run `just check`.
[x] Add a summary of changes to `docs/release_notes.md`.
[x] Add your name to `docs/authors.md` (in alphabetical order).

