### PR TITLE
Tweak dev minimal deps

### DIFF
--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -4,7 +4,8 @@
 
 * Add `--version` flag to `lint-imports` and `import-linter` commands.
 * Make `fastapi` and `uvicorn` optional via the `ui` extra (`pip install import-linter[ui]`).
-* Bugfix: fix back button navigation in explore command. 
+* Bugfix: fix back button navigation in explore command.
+* Provide lower limits for `fastapi` and `uvicorn` in `pyproject.toml`.
 
 ## 2.10 (2026-02-06)
 

--- a/justfile
+++ b/justfile
@@ -11,7 +11,7 @@ test:
     # Run all tests except the ones that are marked with no_ui_deps_installed:
     @uv run pytest -m "not no_ui_deps_installed"
     # Run the no_ui_deps_installed tests under a different dependency group:
-    @uv run --exact --group dev-no-ui --no-dev pytest -m "no_ui_deps_installed"
+    @uv run --exact --group dev-minimal --no-dev pytest -m "no_ui_deps_installed"
 
 
 # Runs tests under all supported Python versions, in parallel.

--- a/justfile
+++ b/justfile
@@ -11,7 +11,7 @@ test:
     # Run all tests except the ones that are marked with no_ui_deps_installed:
     @uv run pytest -m "not no_ui_deps_installed"
     # Run the no_ui_deps_installed tests under a different dependency group:
-    @uv run --exact --group dev-no-ui --no-group dev pytest -m "no_ui_deps_installed"
+    @uv run --exact --group dev-no-ui --no-dev pytest -m "no_ui_deps_installed"
 
 
 # Runs tests under all supported Python versions, in parallel.

--- a/justfile
+++ b/justfile
@@ -16,13 +16,9 @@ test:
 
 # Runs tests under all supported Python versions, in parallel.
 [parallel]
-test-all: test-3-9 test-3-10 test-3-11 test-3-12 test-3-13 test-3-14
+test-all: test-3-10 test-3-11 test-3-12 test-3-13 test-3-14
 # Note that all recipes called from this must use UV_LINK_MODE=copy,
 # otherwise the parallelism can corrupt the virtual environments.
-
-# Runs tests under Python 3.9.
-test-3-9:
-    @UV_LINK_MODE=copy UV_PYTHON=3.9 just test
 
 # Runs tests under Python 3.10.
 test-3-10:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,8 +35,8 @@ readme = "README.md"
 
 [project.optional-dependencies]
 ui = [
-    "fastapi",
-    "uvicorn",
+    "fastapi>=0.115",
+    "uvicorn>=0.11",
 ]
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,10 +99,10 @@ import-linter = { workspace = true }
 
 [dependency-groups]
 dev = [
-    {include-group = "dev-no-ui"},
+    {include-group = "dev-minimal"},
     "import-linter[ui]",
 ]
-dev-no-ui = [
+dev-minimal = [
     "httpx>=0.28.1",
     "mypy>=1.18.2",
     "pre-commit>=4.3.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,9 +101,9 @@ import-linter = { workspace = true }
 dev = [
     {include-group = "dev-minimal"},
     "import-linter[ui]",
+    "httpx>=0.28.1",
 ]
 dev-minimal = [
-    "httpx>=0.28.1",
     "mypy>=1.18.2",
     "pre-commit>=4.3.0",
     "pytest>=8.4.2",

--- a/uv.lock
+++ b/uv.lock
@@ -470,7 +470,6 @@ dev = [
     { name = "types-pyyaml" },
 ]
 dev-minimal = [
-    { name = "httpx" },
     { name = "mypy" },
     { name = "pre-commit" },
     { name = "pytest" },
@@ -514,7 +513,6 @@ dev = [
     { name = "types-pyyaml", specifier = ">=6.0.12.20250915" },
 ]
 dev-minimal = [
-    { name = "httpx", specifier = ">=0.28.1" },
     { name = "mypy", specifier = ">=1.18.2" },
     { name = "pre-commit", specifier = ">=4.3.0" },
     { name = "pytest", specifier = ">=8.4.2" },

--- a/uv.lock
+++ b/uv.lock
@@ -469,7 +469,7 @@ dev = [
     { name = "tox" },
     { name = "types-pyyaml" },
 ]
-dev-no-ui = [
+dev-minimal = [
     { name = "httpx" },
     { name = "mypy" },
     { name = "pre-commit" },
@@ -513,7 +513,7 @@ dev = [
     { name = "tox", specifier = ">=4.30.2" },
     { name = "types-pyyaml", specifier = ">=6.0.12.20250915" },
 ]
-dev-no-ui = [
+dev-minimal = [
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "mypy", specifier = ">=1.18.2" },
     { name = "pre-commit", specifier = ">=4.3.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -224,7 +224,7 @@ wheels = [
 
 [[package]]
 name = "fastapi"
-version = "0.128.2"
+version = "0.135.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-doc" },
@@ -233,9 +233,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4f/6e/45fb5390d46d7918426ea1c1ec4b06c1d3fd70be4a47a690ccb4f1f9438a/fastapi-0.128.2.tar.gz", hash = "sha256:7db9eb891866ac3a08e03f844b99e343a2c1cc41247e68e006c90b38d2464ea1", size = 376129, upload-time = "2026-02-05T19:48:33.957Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/7b/f8e0211e9380f7195ba3f3d40c292594fd81ba8ec4629e3854c353aaca45/fastapi-0.135.1.tar.gz", hash = "sha256:d04115b508d936d254cea545b7312ecaa58a7b3a0f84952535b4c9afae7668cd", size = 394962, upload-time = "2026-03-01T18:18:29.369Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c1/f2/80df24108572630bb2adef3d97f1e774b18ec25bfbab5528f36cba6478c0/fastapi-0.128.2-py3-none-any.whl", hash = "sha256:55bfd9490ca0125707d80e785583c2dc57840bb66e3a0bbc087d20c364964dc0", size = 104032, upload-time = "2026-02-05T19:48:32.118Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/72/42e900510195b23a56bde950d26a51f8b723846bfcaa0286e90287f0422b/fastapi-0.135.1-py3-none-any.whl", hash = "sha256:46e2fc5745924b7c840f71ddd277382af29ce1cdb7d5eab5bf697e3fb9999c9e", size = 116999, upload-time = "2026-03-01T18:18:30.831Z" },
 ]
 
 [[package]]
@@ -491,12 +491,12 @@ docs = [
 [package.metadata]
 requires-dist = [
     { name = "click", specifier = ">=6" },
-    { name = "fastapi", marker = "extra == 'ui'" },
+    { name = "fastapi", marker = "extra == 'ui'", specifier = ">=0.115" },
     { name = "grimp", specifier = ">=3.14" },
     { name = "rich", specifier = ">=14.2.0" },
     { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=1.2.1" },
     { name = "typing-extensions", specifier = ">=3.10.0.0" },
-    { name = "uvicorn", marker = "extra == 'ui'" },
+    { name = "uvicorn", marker = "extra == 'ui'", specifier = ">=0.11" },
 ]
 provides-extras = ["ui"]
 


### PR DESCRIPTION
Makes a few tweaks to the management of the optional dev dependencies. The only one that could affect users is to define minimal versions for `fastapi` and `unicorn`, which I should have done before!

I'd like to add testing of these earlier dependencies into CI, but I'll do that in a separate PR.