### PR TITLE
Nox

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,16 +10,8 @@ on:
 
 jobs:
   test:
-    name: Test under ${{ matrix.python-version }}
+    name: Test under supported Python versions
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version:  # All Python versions supported by Import Linter.
-          - "3.10"
-          - "3.11"
-          - "3.12"
-          - "3.13"
-          - "3.14"
 
     steps:
       - uses: actions/checkout@v5
@@ -33,7 +25,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Test
-        run: just test
+        run: just test-all
 
   lint:
     name: Lint under ${{ matrix.python-version }}

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -92,10 +92,17 @@ When you're developing a feature, you'll probably want to run tests quickly, usi
 just test
 ```
 
-There are also version-specific test commands (e.g. `just test-3-13`) - run `just help` to see which ones.
+You can also pass a specific Python version, e.g. `just test --python=3.13`.
 
-Finally, you can run all of the tests in parallel with `just test-all`. This gives a more complete picture of whether
-the changes are compatible with all supported versions, but any failure output may be difficult to read.
+If you want to invoke pytest directly, e.g. to run a specific test, just use `uv run pytest`, e.g.:
+
+```console
+uv run pytest tests/unit/contracts
+```
+
+Finally, you can run all the tests under all supported Python versions with `just test-all`. This gives a more complete
+picture of whether the changes are compatible with all supported versions. Additionally, it will run tests under the
+*lowest* versions of dependencies specified in `pyproject.toml`, with the lowest supported Python version. 
 
 ### Before you push
 

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -6,6 +6,7 @@
 * Make `fastapi` and `uvicorn` optional via the `ui` extra (`pip install import-linter[ui]`).
 * Bugfix: fix back button navigation in explore command.
 * Provide lower limits for `fastapi` and `uvicorn` in `pyproject.toml`.
+* Switch to nox for testing.  
 
 ## 2.10 (2026-02-06)
 

--- a/justfile
+++ b/justfile
@@ -10,39 +10,13 @@ install-precommit:
 nox *args:
     @uv run --group nox nox {{args}}
 
-# Runs tests under the latest supported Python version.
-test:
-    # Run all tests except the ones that are marked with no_ui_deps_installed:
-    @uv run pytest -m "not no_ui_deps_installed"
-    # Run the no_ui_deps_installed tests under a different dependency group:
-    @uv run --exact --group dev-minimal --no-dev pytest -m "no_ui_deps_installed"
+# Runs tests under the supplied Python version.
+test python="3.14":
+    @just nox --python {{python}}
 
-
-# Runs tests under all supported Python versions, in parallel.
-[parallel]
-test-all: test-3-10 test-3-11 test-3-12 test-3-13 test-3-14
-# Note that all recipes called from this must use UV_LINK_MODE=copy,
-# otherwise the parallelism can corrupt the virtual environments.
-
-# Runs tests under Python 3.10.
-test-3-10:
-    @UV_LINK_MODE=copy UV_PYTHON=3.10 just test
-
-# Runs tests under Python 3.11.
-test-3-11:
-    @UV_LINK_MODE=copy UV_PYTHON=3.11 just test
-
-# Runs tests under Python 3.12.
-test-3-12:
-    @UV_LINK_MODE=copy UV_PYTHON=3.12 just test
-
-# Runs tests under Python 3.13.
-test-3-13:
-    @UV_LINK_MODE=copy UV_PYTHON=3.13 just test
-
-# Runs tests under Python 3.14.
-test-3-14:
-    @UV_LINK_MODE=copy UV_PYTHON=3.14 just test
+# Runs tests under all supported Python versions.
+test-all:
+    @uv run --group nox nox
 
 
 # Format the code.

--- a/justfile
+++ b/justfile
@@ -6,6 +6,10 @@ help:
 install-precommit:
     @uv run pre-commit install
 
+# Run nox.
+nox *args:
+    @uv run --group nox nox {{args}}
+
 # Runs tests under the latest supported Python version.
 test:
     # Run all tests except the ones that are marked with no_ui_deps_installed:

--- a/noxfile.py
+++ b/noxfile.py
@@ -30,3 +30,42 @@ def test_without_ui_deps_installed(session: nox.Session) -> None:
     Run the tests that are specifically for when the `ui` extra is not installed.
     """
     session.run("pytest", "-m", "no_ui_deps_installed")
+
+
+@nox.session(python=[EARLIEST_PYTHON])
+@nox.parametrize("with_ui", [True, False])
+def test_earliest_dependencies(session: nox.Session, with_ui: bool) -> None:
+    """
+    Try to detect any compatibility issues with lower bounds of our dependencies.
+
+    We run the tests on the earliest version of Python and use the lowest-direct resolution
+    strategy to install the lowest direct dependencies listed in pyproject.toml.
+    """
+    session.install("uv")
+
+    if with_ui:
+        # Install ui extra.
+        package = ".[ui]"
+        group = "dev"
+        # Run all tests except the ones that should only be run when the ui deps aren't installed.
+        pytest_mark = "not no_ui_deps_installed"
+    else:
+        package = "."
+        group = "dev-minimal"
+        # Run the tests specifically for when the ui deps aren't installed.
+        pytest_mark = "no_ui_deps_installed"
+
+    # We can't use nox_uv for this one, nor `uv run`, as it will overwrite the project's uv.lock file.
+    # Instead we use uv to install the lowest dependencies into the virtualenv provided by nox.
+    session.run(
+        "uv",
+        "pip",
+        "install",
+        package,
+        "--group",
+        group,
+        "--resolution=lowest-direct",
+        env={"VIRTUAL_ENV": session.virtualenv.location},
+    )
+
+    session.run("pytest", "-m", pytest_mark)

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,0 +1,32 @@
+import nox
+import nox_uv
+
+nox.options.default_venv_backend = "uv"
+
+PYPROJECT = nox.project.load_toml("pyproject.toml")
+PYTHON_VERSIONS = nox.project.python_versions(PYPROJECT)
+EARLIEST_PYTHON = PYTHON_VERSIONS[0]
+
+
+@nox_uv.session(
+    python=PYTHON_VERSIONS,
+    uv_groups=["dev"],
+)
+def test_with_ui_deps_installed(session: nox.Session) -> None:
+    """
+    Run tests that assume the `ui` extra is installed.
+
+    (This is most of the tests.)
+    """
+    session.run("pytest", "-m", "not no_ui_deps_installed")
+
+
+@nox_uv.session(
+    python=PYTHON_VERSIONS,
+    uv_groups=["dev-minimal"],
+)
+def test_without_ui_deps_installed(session: nox.Session) -> None:
+    """
+    Run the tests that are specifically for when the `ui` extra is not installed.
+    """
+    session.run("pytest", "-m", "no_ui_deps_installed")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,8 +35,8 @@ readme = "README.md"
 
 [project.optional-dependencies]
 ui = [
-    "fastapi>=0.115",
-    "uvicorn>=0.11",
+    "fastapi>=0.113",
+    "uvicorn>=0.17.1",
 ]
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,3 +119,6 @@ docs = [
     "sphinx>=7.4.7",
     "sphinx-rtd-theme>=3.0.2",
 ]
+nox = [
+    "nox-uv>=0.7.1",
+]

--- a/uv.lock
+++ b/uv.lock
@@ -49,6 +49,24 @@ wheels = [
 ]
 
 [[package]]
+name = "argcomplete"
+version = "3.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/38/61/0b9ae6399dd4a58d8c1b1dc5a27d6f2808023d0b5dd3104bb99f45a33ff6/argcomplete-3.6.3.tar.gz", hash = "sha256:62e8ed4fd6a45864acc8235409461b72c9a28ee785a2011cc5eb78318786c89c", size = 73754, upload-time = "2025-10-20T03:33:34.741Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/74/f5/9373290775639cb67a2fce7f629a1c240dce9f12fe927bc32b2736e16dfc/argcomplete-3.6.3-py3-none-any.whl", hash = "sha256:f5007b3a600ccac5d25bbce33089211dfd49eab4a7718da3f10e3082525a92ce", size = 43846, upload-time = "2025-10-20T03:33:33.021Z" },
+]
+
+[[package]]
+name = "attrs"
+version = "25.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6b/5c/685e6633917e101e5dcb62b9dd76946cbb57c26e133bae9e0cd36033c0a9/attrs-25.4.0.tar.gz", hash = "sha256:16d5969b87f0859ef33a48b35d55ac1be6e42ae49d5e853b597db70c35c57e11", size = 934251, upload-time = "2025-10-06T13:54:44.725Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3a/2a/7cc015f5b9f5db42b7d48157e23356022889fc354a2813c15934b7cb5c0e/attrs-25.4.0-py3-none-any.whl", hash = "sha256:adcf7e2a1fb3b36ac48d97835bb6d8ade15b8dcce26aba8bf1d14847b57a3373", size = 67615, upload-time = "2025-10-06T13:54:43.17Z" },
+]
+
+[[package]]
 name = "babel"
 version = "2.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -190,6 +208,31 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "colorlog"
+version = "6.10.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a2/61/f083b5ac52e505dfc1c624eafbf8c7589a0d7f32daa398d2e7590efa5fda/colorlog-6.10.1.tar.gz", hash = "sha256:eb4ae5cb65fe7fec7773c2306061a8e63e02efc2c72eba9d27b0fa23c94f1321", size = 17162, upload-time = "2025-10-16T16:14:11.978Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6d/c1/e419ef3723a074172b68aaa89c9f3de486ed4c2399e2dbd8113a4fdcaf9e/colorlog-6.10.1-py3-none-any.whl", hash = "sha256:2d7e8348291948af66122cff006c9f8da6255d224e7cf8e37d8de2df3bad8c9c", size = 11743, upload-time = "2025-10-16T16:14:10.512Z" },
+]
+
+[[package]]
+name = "dependency-groups"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/62/55/f054de99871e7beb81935dea8a10b90cd5ce42122b1c3081d5282fdb3621/dependency_groups-1.3.1.tar.gz", hash = "sha256:78078301090517fd938c19f64a53ce98c32834dfe0dee6b88004a569a6adfefd", size = 10093, upload-time = "2025-05-02T00:34:29.452Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/c7/d1ec24fb280caa5a79b6b950db565dab30210a66259d17d5bb2b3a9f878d/dependency_groups-1.3.1-py3-none-any.whl", hash = "sha256:51aeaa0dfad72430fcfb7bcdbefbd75f3792e5919563077f30bc0d73f4493030", size = 8664, upload-time = "2025-05-02T00:34:27.085Z" },
 ]
 
 [[package]]
@@ -412,6 +455,15 @@ wheels = [
 ]
 
 [[package]]
+name = "humanize"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/66/a3921783d54be8a6870ac4ccffcd15c4dc0dd7fcce51c6d63b8c63935276/humanize-4.15.0.tar.gz", hash = "sha256:1dd098483eb1c7ee8e32eb2e99ad1910baefa4b75c3aff3a82f4d78688993b10", size = 83599, upload-time = "2025-12-20T20:16:13.19Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c5/7b/bca5613a0c3b542420cf92bd5e5fb8ebd5435ce1011a091f66bb7693285e/humanize-4.15.0-py3-none-any.whl", hash = "sha256:b1186eb9f5a9749cd9cb8565aee77919dd7c8d076161cf44d70e59e3301e1769", size = 132203, upload-time = "2025-12-20T20:16:11.67Z" },
+]
+
+[[package]]
 name = "identify"
 version = "2.6.14"
 source = { registry = "https://pypi.org/simple" }
@@ -486,6 +538,9 @@ docs = [
     { name = "sphinx", version = "8.2.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "sphinx-rtd-theme" },
 ]
+nox = [
+    { name = "nox-uv" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -528,6 +583,7 @@ docs = [
     { name = "sphinx", specifier = ">=7.4.7" },
     { name = "sphinx-rtd-theme", specifier = ">=3.0.2" },
 ]
+nox = [{ name = "nox-uv", specifier = ">=0.7.1" }]
 
 [[package]]
 name = "iniconfig"
@@ -804,6 +860,37 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/43/16/fc88b08840de0e0a72a2f9d8c6bae36be573e475a6326ae854bcc549fc45/nodeenv-1.9.1.tar.gz", hash = "sha256:6ec12890a2dab7946721edbfbcd91f3319c6ccc9aec47be7c7e6b7011ee6645f", size = 47437, upload-time = "2024-06-04T18:44:11.171Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d2/1d/1b658dbd2b9fa9c4c9f32accbfc0205d532c8c6194dc0f2a4c0428e7128a/nodeenv-1.9.1-py2.py3-none-any.whl", hash = "sha256:ba11c9782d29c27c70ffbdda2d7415098754709be8a7056d79a737cd901155c9", size = 22314, upload-time = "2024-06-04T18:44:08.352Z" },
+]
+
+[[package]]
+name = "nox"
+version = "2026.2.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "argcomplete" },
+    { name = "attrs" },
+    { name = "colorlog" },
+    { name = "dependency-groups" },
+    { name = "humanize" },
+    { name = "packaging" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "virtualenv" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6e/8e/55a9679b31f1efc48facedd2448eb53c7f1e647fb592aa1403c9dd7a4590/nox-2026.2.9.tar.gz", hash = "sha256:1bc8a202ee8cd69be7aaada63b2a7019126899a06fc930a7aee75585bf8ee41b", size = 4031165, upload-time = "2026-02-10T04:38:58.878Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8d/58/0d5e5a044f1868bdc45f38afdc2d90ff9867ce398b4e8fa9e666bfc9bfba/nox-2026.2.9-py3-none-any.whl", hash = "sha256:1b7143bc8ecdf25f2353201326152c5303ae4ae56ca097b1fb6179ad75164c47", size = 74615, upload-time = "2026-02-10T04:38:57.266Z" },
+]
+
+[[package]]
+name = "nox-uv"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nox" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/04/e8/670919c513c22f4bf1656d84dd99a9ad1a5eaaeadf2457bab3efeeac14e0/nox_uv-0.7.1.tar.gz", hash = "sha256:f075d610b4648732fd17cbc9fa48be7d2c23df7b188fed3e4e6dde7bd1f14f20", size = 5124, upload-time = "2026-02-05T03:55:34.807Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4f/0a/a6798a215366c9b034e92a9992d9013da5f544a488216fc54204ccf3c134/nox_uv-0.7.1-py3-none-any.whl", hash = "sha256:91361cc282a0a764de1b94ad002b67d5b43de4adc3f56e16d1b79928c8ec0433", size = 5457, upload-time = "2026-02-05T03:55:35.994Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -490,12 +490,12 @@ docs = [
 [package.metadata]
 requires-dist = [
     { name = "click", specifier = ">=6" },
-    { name = "fastapi", marker = "extra == 'ui'", specifier = ">=0.115" },
+    { name = "fastapi", marker = "extra == 'ui'", specifier = ">=0.113" },
     { name = "grimp", specifier = ">=3.14" },
     { name = "rich", specifier = ">=14.2.0" },
     { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=1.2.1" },
     { name = "typing-extensions", specifier = ">=3.10.0.0" },
-    { name = "uvicorn", marker = "extra == 'ui'", specifier = ">=0.11" },
+    { name = "uvicorn", marker = "extra == 'ui'", specifier = ">=0.17.1" },
 ]
 provides-extras = ["ui"]
 


### PR DESCRIPTION
Add nox for testing different Python versions.

The main reason for this is to add support for testing the earliest dependencies in the pyproject.toml under the earliest Python version. It's awkward to do that using uv alone, as using different resolution strategies causes the `uv.lock` file to change.

```
nox > Ran 12 sessions in a minute:
nox > * test_with_ui_deps_installed-3.10: success, took 10 seconds
nox > * test_with_ui_deps_installed-3.11: success, took 9 seconds
nox > * test_with_ui_deps_installed-3.12: success, took 8 seconds
nox > * test_with_ui_deps_installed-3.13: success, took 9 seconds
nox > * test_with_ui_deps_installed-3.14: success, took 10 seconds
nox > * test_without_ui_deps_installed-3.10: success, took a second
nox > * test_without_ui_deps_installed-3.11: success
nox > * test_without_ui_deps_installed-3.12: success, took a second
nox > * test_without_ui_deps_installed-3.13: success, took a second
nox > * test_without_ui_deps_installed-3.14: success, took a second
nox > * test_earliest_dependencies-3.10(with_ui=True): success, took 8 seconds
nox > * test_earliest_dependencies-3.10(with_ui=False): success, took a second
```

