### PR TITLE
Show module docstrings in the explore UI

### DIFF
--- a/docs/authors.md
+++ b/docs/authors.md
@@ -12,6 +12,7 @@
 * [Christoph Gietl](https://github.com/christophgietl)
 * [Daniel Jurczak](https://github.com/danieljurczak)
 * [Daniele Esposti](https://github.com/expobrain)
+* [Ederson Lima](https://github.com/Edim)
 * [Fabian Binz](https://github.com/fbinz)
 * [Felix Uhl](https://github.com/iFreilicht)
 * [Ilya S. (Tapeline)](https://github.com/Tapeline)

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -1,5 +1,11 @@
 # Release notes
 
+## latest
+
+* Show module docstring below the breadcrumb bar when exploring a package.
+* Show module docstring in a tooltip when hovering over graph nodes.
+
+
 ## 2.11 (2026-03-06)
 
 * Add `--version` flag to `lint-imports` and `import-linter` commands.

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -42,6 +42,14 @@ An arrow can be read as saying "depends on". If package `one` points to `two`, t
 Click on any package node in the graph to drill down into it and see its children.
 Only packages (modules that contain submodules) are clickable.
 
+Hovering over a node shows a tooltip. For packages, the tooltip shows the name of the
+module you'll navigate to; if the module has a docstring, its description is also shown.
+
+### Module descriptions
+
+When a package has a docstring in its `__init__.py`, a brief description is shown below
+the breadcrumb bar. This can help you understand the purpose of a package at a glance.
+
 ## Options
 
 The right sidebar provides options to customize the visualization.

--- a/src/importlinter/ui/explorer.py
+++ b/src/importlinter/ui/explorer.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+import ast
+import importlib.util
 import logging
 from dataclasses import dataclass
+from pathlib import Path
 
 import grimp
 from collections.abc import Set
@@ -19,6 +22,8 @@ class ModuleDot:
     module: str
     # Any children that are packages, and therefore can be drilled down into.
     child_packages: Set[str]
+    description: str | None
+    child_descriptions: dict[str, str | None]
 
 
 def _get_grimp_graph(
@@ -45,9 +50,21 @@ def generate_dot(
     dot_string = dot_graph.render()
 
     child_packages = _get_child_packages(grimp_graph, module)
+    description = _get_module_description(module)
+
+    children = grimp_graph.find_children(module)
+    child_descriptions = {
+        "." + child.split(".")[-1]: _get_module_description(child) for child in children
+    }
 
     logger.info(f"Graph for '{module}' built ({len(child_packages)} packages).")
-    return ModuleDot(dot_string=dot_string, module=module, child_packages=child_packages)
+    return ModuleDot(
+        dot_string=dot_string,
+        module=module,
+        child_packages=child_packages,
+        description=description,
+        child_descriptions=child_descriptions,
+    )
 
 
 def _get_child_packages(grimp_graph: grimp.ImportGraph, module: str) -> set[str]:
@@ -59,3 +76,17 @@ def _get_child_packages(grimp_graph: grimp.ImportGraph, module: str) -> set[str]
             relative_name = "." + child.split(".")[-1]
             child_packages.add(relative_name)
     return child_packages
+
+
+def _get_module_description(module: str) -> str | None:
+    spec = importlib.util.find_spec(module)
+    if spec is None or spec.origin is None:
+        return None
+    if not spec.origin.endswith("__init__.py"):
+        return None
+    try:
+        source = Path(spec.origin).read_text(encoding="utf-8")
+        tree = ast.parse(source)
+        return ast.get_docstring(tree)
+    except Exception:
+        return None

--- a/src/importlinter/ui/server.py
+++ b/src/importlinter/ui/server.py
@@ -31,6 +31,8 @@ class GraphResponse(TypedDict):
     dot_string: str
     module: str
     child_packages: list[str]
+    description: str | None
+    child_descriptions: dict[str, str | None]
 
 
 class ErrorResponse(TypedDict):

--- a/src/importlinter/ui/static/explorer.js
+++ b/src/importlinter/ui/static/explorer.js
@@ -171,14 +171,60 @@ function restoreFromCache(cached, updateHistory) {
     setupNodeClicks();
 }
 
+function escapeHtml(text) {
+    const div = document.createElement('div');
+    div.textContent = text;
+    return div.innerHTML;
+}
+
+const DOCSTRING_MAX_LEN = 120;
+let fullDocstringHtml = '';
+
 function updateDescription(description) {
-    const el = document.getElementById('module-description');
+    const section = document.getElementById('docstring-section');
+    const textEl = document.getElementById('docstring-text');
+    const showMore = document.getElementById('docstring-show-more');
+    const showLess = document.getElementById('docstring-show-less');
+    const toggle = document.getElementById('docstring-toggle');
+    const content = document.getElementById('docstring-content');
     if (description) {
-        el.textContent = description;
-        el.style.display = 'block';
+        fullDocstringHtml = escapeHtml(description).replace(/\n/g, '<br>');
+        const needsTruncation = description.length > DOCSTRING_MAX_LEN;
+        if (needsTruncation) {
+            textEl.innerHTML = escapeHtml(description.slice(0, DOCSTRING_MAX_LEN)).replace(/\n/g, '<br>') + '...';
+            showMore.style.display = 'inline-block';
+        } else {
+            textEl.innerHTML = fullDocstringHtml;
+            showMore.style.display = 'none';
+        }
+        showLess.style.display = 'none';
+        section.style.display = 'flex';
+        content.style.display = 'block';
+        toggle.classList.remove('collapsed');
     } else {
-        el.style.display = 'none';
+        section.style.display = 'none';
     }
+}
+
+function expandDocstring() {
+    document.getElementById('docstring-text').innerHTML = fullDocstringHtml;
+    document.getElementById('docstring-show-more').style.display = 'none';
+    document.getElementById('docstring-show-less').style.display = 'inline-block';
+}
+
+function collapseDocstring() {
+    const textEl = document.getElementById('docstring-text');
+    textEl.innerHTML = escapeHtml(currentDescription.slice(0, DOCSTRING_MAX_LEN)).replace(/\n/g, '<br>') + '...';
+    document.getElementById('docstring-show-more').style.display = 'inline-block';
+    document.getElementById('docstring-show-less').style.display = 'none';
+}
+
+function toggleDocstring() {
+    const content = document.getElementById('docstring-content');
+    const toggle = document.getElementById('docstring-toggle');
+    const isVisible = content.style.display !== 'none';
+    content.style.display = isVisible ? 'none' : 'block';
+    toggle.classList.toggle('collapsed', isVisible);
 }
 
 function updateBreadcrumb() {
@@ -336,7 +382,9 @@ function showNodeTooltip(tooltip, nodeName, isPackage) {
     if (description) {
         const descEl = document.createElement('div');
         descEl.className = 'tooltip-desc';
-        descEl.textContent = description;
+        const maxLen = 120;
+        const text = description.replace(/\n/g, ' ');
+        descEl.textContent = text.length > maxLen ? text.slice(0, maxLen) + '...' : text;
         tooltip.appendChild(descEl);
     }
 

--- a/src/importlinter/ui/static/explorer.js
+++ b/src/importlinter/ui/static/explorer.js
@@ -10,6 +10,8 @@ let currentModule = null;
 let navigationHistory = [];
 let vizInstance = null;
 let currentPackages = [];
+let currentDescription = null;
+let currentChildDescriptions = {};
 
 // Settings state
 let showImportTotals = false;
@@ -75,7 +77,10 @@ async function loadGraph(moduleName = null, updateHistory = true) {
 
         currentModule = data.module;
         currentPackages = data.child_packages || [];
+        currentDescription = data.description || null;
+        currentChildDescriptions = data.child_descriptions || {};
         updateBreadcrumb();
+        updateDescription(currentDescription);
 
         if (updateHistory) {
             updateUrl(currentModule);
@@ -127,6 +132,8 @@ async function loadGraph(moduleName = null, updateHistory = true) {
         graphCache.set(cacheKey, {
             module: currentModule,
             packages: currentPackages,
+            description: currentDescription,
+            childDescriptions: currentChildDescriptions,
             svgElement: svgElement.cloneNode(true),
             viewBox: { ...originalViewBox }
         });
@@ -141,7 +148,10 @@ async function loadGraph(moduleName = null, updateHistory = true) {
 function restoreFromCache(cached, updateHistory) {
     currentModule = cached.module;
     currentPackages = [...cached.packages];
+    currentDescription = cached.description || null;
+    currentChildDescriptions = cached.childDescriptions || {};
     updateBreadcrumb();
+    updateDescription(currentDescription);
 
     if (updateHistory) {
         updateUrl(currentModule);
@@ -159,6 +169,16 @@ function restoreFromCache(cached, updateHistory) {
 
     setupPanZoom();
     setupNodeClicks();
+}
+
+function updateDescription(description) {
+    const el = document.getElementById('module-description');
+    if (description) {
+        el.textContent = description;
+        el.style.display = 'block';
+    } else {
+        el.style.display = 'none';
+    }
 }
 
 function updateBreadcrumb() {
@@ -301,6 +321,30 @@ function resetView() {
     }
 }
 
+function showNodeTooltip(tooltip, nodeName, isPackage) {
+    tooltip.innerHTML = '';
+    const childName = nodeName.startsWith('.') ? nodeName.slice(1) : nodeName;
+
+    if (isPackage) {
+        const titleEl = document.createElement('div');
+        titleEl.className = 'tooltip-title';
+        titleEl.textContent = `Explore ${currentModule}.${childName}`;
+        tooltip.appendChild(titleEl);
+    }
+
+    const description = currentChildDescriptions[nodeName];
+    if (description) {
+        const descEl = document.createElement('div');
+        descEl.className = 'tooltip-desc';
+        descEl.textContent = description;
+        tooltip.appendChild(descEl);
+    }
+
+    if (tooltip.children.length > 0) {
+        tooltip.style.display = 'block';
+    }
+}
+
 function setupNodeClicks() {
     if (!svg) return;
 
@@ -311,6 +355,7 @@ function setupNodeClicks() {
         const title = node.querySelector('title');
         const nodeName = title ? title.textContent : 'Unknown';
         const isPackage = currentPackages.includes(nodeName);
+        const hasDescription = Boolean(currentChildDescriptions[nodeName]);
 
         if (isPackage) {
             node.classList.add('package');
@@ -325,11 +370,11 @@ function setupNodeClicks() {
                 tooltip.style.display = 'none';
                 drillDown(nodeName);
             });
+        }
 
-            node.addEventListener('mouseenter', (e) => {
-                const childName = nodeName.startsWith('.') ? nodeName.slice(1) : nodeName;
-                tooltip.textContent = `Explore ${currentModule}.${childName}`;
-                tooltip.style.display = 'block';
+        if (isPackage || hasDescription) {
+            node.addEventListener('mouseenter', () => {
+                showNodeTooltip(tooltip, nodeName, isPackage);
             });
 
             node.addEventListener('mousemove', (e) => {

--- a/src/importlinter/ui/static/index.html
+++ b/src/importlinter/ui/static/index.html
@@ -16,6 +16,7 @@
         <span class="prefix">Import graph for</span>
         <span class="current">{{module_name}}</span>
     </div>
+    <div id="module-description"></div>
     <main>
         <div id="graph-container">
             <div id="loading"><div class="spinner"></div><div class="text">Loading graph...</div></div>

--- a/src/importlinter/ui/static/index.html
+++ b/src/importlinter/ui/static/index.html
@@ -16,7 +16,6 @@
         <span class="prefix">Import graph for</span>
         <span class="current">{{module_name}}</span>
     </div>
-    <div id="module-description"></div>
     <main>
         <div id="graph-container">
             <div id="loading"><div class="spinner"></div><div class="text">Loading graph...</div></div>
@@ -25,6 +24,16 @@
             <div id="tooltip"></div>
         </div>
         <div id="sidebar">
+            <div id="docstring-section" class="sidebar-section" style="display: none;">
+                <h2 class="docstring-header" onclick="toggleDocstring()">
+                    Module docstring <span id="docstring-toggle" class="docstring-toggle-icon">&#x25BC;</span>
+                </h2>
+                <div id="docstring-content" class="docstring-body">
+                    <span id="docstring-text"></span>
+                    <a id="docstring-show-more" class="docstring-toggle-link" onclick="expandDocstring()">Show more</a>
+                    <a id="docstring-show-less" class="docstring-toggle-link" onclick="collapseDocstring()" style="display: none;">Show less</a>
+                </div>
+            </div>
             <div id="nav-section" class="sidebar-section">
                 <h2>Navigation</h2>
                 <div class="sidebar-buttons">

--- a/src/importlinter/ui/static/styles.css
+++ b/src/importlinter/ui/static/styles.css
@@ -65,13 +65,41 @@ header h1 {
     font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace;
 }
 
-#module-description {
-    padding: 0.4rem 1rem;
+.docstring-header {
+    cursor: pointer;
+    user-select: none;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.docstring-toggle-icon {
+    font-size: 0.7rem;
+    transition: transform 0.2s;
     color: #888;
-    font-style: italic;
-    font-size: 0.9rem;
-    background: #1a1a1a;
-    display: none;
+}
+
+.docstring-toggle-icon.collapsed {
+    transform: rotate(-90deg);
+}
+
+.docstring-body {
+    font-size: 0.85rem;
+    color: #ccc;
+    line-height: 1.5;
+    word-wrap: break-word;
+}
+
+.docstring-toggle-link {
+    display: inline-block;
+    margin-top: 0.3rem;
+    color: #6af;
+    cursor: pointer;
+    font-size: 0.8rem;
+}
+
+.docstring-toggle-link:hover {
+    text-decoration: underline;
 }
 
 main {

--- a/src/importlinter/ui/static/styles.css
+++ b/src/importlinter/ui/static/styles.css
@@ -65,6 +65,15 @@ header h1 {
     font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace;
 }
 
+#module-description {
+    padding: 0.4rem 1rem;
+    color: #888;
+    font-style: italic;
+    font-size: 0.9rem;
+    background: #1a1a1a;
+    display: none;
+}
+
 main {
     flex: 1;
     display: flex;
@@ -324,6 +333,20 @@ main {
     color: #e74c3c;
     text-align: center;
     display: none;
+}
+
+.tooltip-title {
+    font-weight: 500;
+}
+
+.tooltip-desc {
+    font-style: italic;
+    color: #aaa;
+    margin-top: 0.35rem;
+    font-size: 0.8rem;
+    max-width: 280px;
+    line-height: 1.4;
+    white-space: normal;
 }
 
 #tooltip {

--- a/src/importlinter/ui/static/styles.css
+++ b/src/importlinter/ui/static/styles.css
@@ -187,6 +187,7 @@ main {
     display: flex;
     flex-direction: column;
     gap: 1.5rem;
+    overflow-y: auto;
 }
 
 .sidebar-section {

--- a/tests/assets/testpackage/testpackage/__init__.py
+++ b/tests/assets/testpackage/testpackage/__init__.py
@@ -1,0 +1,1 @@
+"""A test package for use in import-linter's test suite."""

--- a/tests/assets/testpackage/testpackage/__init__.py
+++ b/tests/assets/testpackage/testpackage/__init__.py
@@ -1,1 +1,6 @@
-"""A test package for use in import-linter's test suite."""
+"""A test package for use in import-linter's test suite.
+
+This package contains high, medium, and low layers
+to exercise layered-architecture contracts.
+It also includes an indirect sub-package for testing
+indirect dependency detection."""

--- a/tests/assets/testpackage/testpackage/high/__init__.py
+++ b/tests/assets/testpackage/testpackage/high/__init__.py
@@ -1,0 +1,1 @@
+"""High-level modules that other packages depend on."""

--- a/tests/assets/testpackage/testpackage/high/__init__.py
+++ b/tests/assets/testpackage/testpackage/high/__init__.py
@@ -1,1 +1,4 @@
-"""High-level modules that other packages depend on."""
+"""High-level modules that other packages depend on.
+
+This layer should not import from medium or low layers.
+Violations here indicate an architectural boundary breach."""

--- a/tests/assets/testpackage/testpackage/high/blue/__init__.py
+++ b/tests/assets/testpackage/testpackage/high/blue/__init__.py
@@ -1,0 +1,1 @@
+"""Blue component of the high layer."""

--- a/tests/assets/testpackage/testpackage/indirect/__init__.py
+++ b/tests/assets/testpackage/testpackage/indirect/__init__.py
@@ -1,0 +1,1 @@
+"""Modules with indirect dependencies between layers."""

--- a/tests/assets/testpackage/testpackage/low/blue/__init__.py
+++ b/tests/assets/testpackage/testpackage/low/blue/__init__.py
@@ -1,0 +1,1 @@
+"""Blue component of the low layer."""

--- a/tests/assets/testpackage/testpackage/medium/__init__.py
+++ b/tests/assets/testpackage/testpackage/medium/__init__.py
@@ -1,0 +1,1 @@
+"""Mid-level modules forming the middle layer of the architecture."""

--- a/tests/assets/testpackage/testpackage/medium/__init__.py
+++ b/tests/assets/testpackage/testpackage/medium/__init__.py
@@ -1,1 +1,4 @@
-"""Mid-level modules forming the middle layer of the architecture."""
+"""Mid-level modules forming the middle layer of the architecture.
+
+May depend on the high layer but must not import from low.
+Contains business logic that bridges high and low concerns."""

--- a/tests/assets/testpackage/testpackage/medium/blue/__init__.py
+++ b/tests/assets/testpackage/testpackage/medium/blue/__init__.py
@@ -1,0 +1,1 @@
+"""Blue component of the medium layer."""

--- a/tests/functional/test_ui.py
+++ b/tests/functional/test_ui.py
@@ -106,3 +106,35 @@ class TestGraphApi:
         r2 = client.get("/api/graph/testpackage.high")
         assert r1.status_code == 200
         assert r2.status_code == 200
+
+    def test_returns_description_when_docstring_present(self, client):
+        response = client.get("/api/graph/testpackage")
+        data = response.json()
+        assert data["description"] == "A test package for use in import-linter's test suite."
+
+    def test_returns_none_description_for_module_without_docstring(self, client):
+        # testpackage.low/__init__.py has no docstring
+        response = client.get("/api/graph/testpackage.low")
+        data = response.json()
+        assert data["description"] is None
+
+    def test_returns_child_descriptions(self, client):
+        response = client.get("/api/graph/testpackage")
+        data = response.json()
+        assert "child_descriptions" in data
+        assert isinstance(data["child_descriptions"], dict)
+        # testpackage.low has no docstring
+        assert data["child_descriptions"].get(".low") is None
+        # testpackage.high has a docstring
+        assert (
+            data["child_descriptions"].get(".high")
+            == "High-level modules that other packages depend on."
+        )
+
+    def test_returns_child_descriptions_when_drilled_down(self, client):
+        # Drilling into testpackage.high should also expose child descriptions
+        response = client.get("/api/graph/testpackage.high")
+        data = response.json()
+        assert "child_descriptions" in data
+        # testpackage.high.blue has a docstring
+        assert data["child_descriptions"].get(".blue") == "Blue component of the high layer."


### PR DESCRIPTION
When using `import-linter explore`, the UI now surfaces module docstrings in two places:

- **Below the breadcrumb bar**: the docstring of the current package's `__init__.py`
  is shown in italic, giving immediate context about the module being explored.
- **Node tooltips**: hovering over a graph node shows a tooltip with the child module's
  docstring (if available). For package nodes, the tooltip also shows the name of the
  module you'll navigate to on click.

Docstrings are extracted statically via `ast.parse()` + `ast.get_docstring()`, so no
module code is executed during rendering.

## Checklist

- [x] Add tests for the change.
- [x] Add any appropriate documentation.
- [x] Run `just check`.
- [x] Add a summary of changes to `docs/release_notes.md`.
- [x] Add your name to `docs/authors.md` (in alphabetical order).