### PR TITLE
Raise clear error when root_package is a single-file module

### DIFF
--- a/docs/authors.md
+++ b/docs/authors.md
@@ -29,4 +29,5 @@
 * [Peter Byfield](https://github.com/Peter554)
 * [Petter Friberg](https://github.com/flaeppe)
 * [piglei](https://github.com/piglei)
+* [Trevin Chow](https://github.com/tmchow)
 * [Uberto Barbini](https://github.com/uberto)

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -1,5 +1,9 @@
 # Release notes
 
+## latest
+
+* Improve error message when root package is a single-file module.
+
 ## 2.11 (2026-03-06)
 
 * Add `--version` flag to `lint-imports` and `import-linter` commands.

--- a/src/importlinter/application/use_cases.py
+++ b/src/importlinter/application/use_cases.py
@@ -1,4 +1,5 @@
 import importlib
+import importlib.util
 import itertools
 from collections.abc import Set
 from copy import copy, deepcopy
@@ -208,15 +209,7 @@ def _get_spinner(message: str, verbose: bool) -> contextlib.AbstractContextManag
         return console.status(":brick: Building graph...", spinner="point")
 
 
-def _build_graph(
-    root_package_names: list[str],
-    include_external_packages: bool | None,
-    exclude_type_checking_imports: bool,
-    verbose: bool,
-    cache_dir: str | None | type[NotSupplied] = NotSupplied,
-) -> ImportGraph:
-    import importlib.util
-
+def _validate_root_package_names(root_package_names: list[str]) -> None:
     for name in root_package_names:
         spec = importlib.util.find_spec(name)
         if spec is not None and spec.submodule_search_locations is None:
@@ -225,6 +218,16 @@ def _build_graph(
                 f"root_packages should only contain packages (directories with __init__.py), "
                 f"not individual .py files."
             )
+
+
+def _build_graph(
+    root_package_names: list[str],
+    include_external_packages: bool | None,
+    exclude_type_checking_imports: bool,
+    verbose: bool,
+    cache_dir: str | None | type[NotSupplied] = NotSupplied,
+) -> ImportGraph:
+    _validate_root_package_names(root_package_names)
 
     if cache_dir == NotSupplied:
         cache_dir = settings.DEFAULT_CACHE_DIR

--- a/src/importlinter/application/use_cases.py
+++ b/src/importlinter/application/use_cases.py
@@ -22,7 +22,7 @@ from .ports.reporting import Report
 from .rendering import render_exception, render_report, format_duration
 from ..domain.dotfile import DotGraph, Edge
 from .sentinels import NotSupplied
-from .user_options import UserOptions
+from .user_options import InvalidUserOptions, UserOptions
 
 # Public functions
 # ----------------
@@ -215,6 +215,17 @@ def _build_graph(
     verbose: bool,
     cache_dir: str | None | type[NotSupplied] = NotSupplied,
 ) -> ImportGraph:
+    import importlib.util
+
+    for name in root_package_names:
+        spec = importlib.util.find_spec(name)
+        if spec is not None and spec.submodule_search_locations is None:
+            raise InvalidUserOptions(
+                f"'{name}' is a module, not a package. "
+                f"root_packages should only contain packages (directories with __init__.py), "
+                f"not individual .py files."
+            )
+
     if cache_dir == NotSupplied:
         cache_dir = settings.DEFAULT_CACHE_DIR
 

--- a/tests/assets/testpackage/.singlefilemodulecontract.ini
+++ b/tests/assets/testpackage/.singlefilemodulecontract.ini
@@ -1,0 +1,10 @@
+[importlinter]
+root_package = single_file_module
+
+[importlinter:contract:one]
+name = Contract referencing a single-file module as root_package
+type = forbidden
+source_modules =
+    single_file_module
+forbidden_modules =
+    os

--- a/tests/assets/testpackage/single_file_module.py
+++ b/tests/assets/testpackage/single_file_module.py
@@ -1,0 +1,4 @@
+"""A standalone module (not a package) used in tests to verify that
+import-linter raises a clear error when a single-file module is passed
+as a root_package.
+"""

--- a/tests/functional/test_lint_imports.py
+++ b/tests/functional/test_lint_imports.py
@@ -93,6 +93,16 @@ def test_lint_imports(working_directory, config_filename, expected_result):
     assert expected_result == result
 
 
+def test_lint_imports_raises_clear_error_when_root_package_is_single_file(capsys):
+    os.chdir(testpackage_directory)
+
+    result = cli.lint_imports(config_filename=".singlefilemodulecontract.ini")
+
+    assert cli.EXIT_STATUS_ERROR == result
+    captured = capsys.readouterr()
+    assert "'single_file_module' is a module, not a package" in captured.out
+
+
 @pytest.mark.parametrize("is_debug_mode", (True, False))
 def test_lint_imports_debug_mode(is_debug_mode):
     os.chdir(testpackage_directory)


### PR DESCRIPTION
## Summary

When `root_packages` contains a module name that resolves to a `.py` file rather than a package directory, the linter now raises a clear error instead of silently exiting with code 1.

## Problem

Configuring a single-file module (e.g., `main.py`) as a root package would exit with code 1 but print no error message, making it difficult to debug.

## Fix

Added validation in `_build_graph` using `importlib.util.find_spec()` to check whether each root package has `submodule_search_locations` (packages have it, single-file modules don't). When a single-file module is detected, an `InvalidUserOptions` exception is raised with a message explaining the issue.

```
Error: 'main' is a module, not a package. root_packages should only contain
packages (directories with __init__.py), not individual .py files.
```

## Testing

The validation runs before the graph build, so it catches the misconfiguration early and provides an actionable error message through the existing `render_exception` path.

Fixes #349

This contribution was developed with AI assistance (Claude Code).