### PR TITLE
Better reporting of non existent ignored imports

### DIFF
--- a/docs/authors.md
+++ b/docs/authors.md
@@ -6,6 +6,7 @@
 
 * [Aaron Gokaslan](https://github.com/Skylion007)
 * [Alexandre Beaufays](https://github.com/abeaufays)
+* [Amrou Bellalouna](https://github.com/shtlrs)
 * [Anthony Sottile](https://github.com/asottile)
 * [Anton Gruebel](https://github.com/gruebel)
 * [Ben Warren](https://github.com/bwarren)

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -3,6 +3,7 @@
 ## latest
 
 * Improve error message when root package is a single-file module.
+* Alert users with all unmatched ignored imports in the same run.
 
 ## 2.11 (2026-03-06)
 

--- a/src/importlinter/application/contract_utils.py
+++ b/src/importlinter/application/contract_utils.py
@@ -27,7 +27,7 @@ def remove_ignored_imports(
         unmatched_alerting: An AlertLevel that indicates how to handle any import expressions that
                             don't match any imports. AlertLevel.NONE will ignore them,
                             AlertLevel.WARN will warn for each one, and AlertLevel.ERROR will raise
-                            a MissingImport for the first one encountered.
+                            a MissingImport with all unmatched imports.
 
     Returns:
         A list of any warnings to be surfaced to the user.
@@ -88,8 +88,8 @@ def _handle_unresolved_import_expressions(
     if alert_level is AlertLevel.WARN:
         return [_build_missing_import_message(expression) for expression in expressions]
     else:  # AlertLevel.ERROR
-        first_expression = sorted(expressions, key=lambda expression: str(expression))[0]
-        raise MissingImport(_build_missing_import_message(first_expression))
+        messages = [_build_missing_import_message(expr) for expr in expressions]
+        raise MissingImport("\n".join(messages))
 
 
 def _build_missing_import_message(expression: ImportExpression) -> str:

--- a/src/importlinter/application/contract_utils.py
+++ b/src/importlinter/application/contract_utils.py
@@ -33,7 +33,7 @@ def remove_ignored_imports(
         A list of any warnings to be surfaced to the user.
     """
     imports_to_remove = set()
-    unresolved_expressions = set()
+    unresolved_expressions = []
     for import_expression in ignore_imports or []:
         matched_imports = graph.find_matching_direct_imports(
             import_expression=str(import_expression)
@@ -49,7 +49,8 @@ def remove_ignored_imports(
                 }
             )
         else:
-            unresolved_expressions.add(import_expression)
+            if import_expression not in unresolved_expressions:
+                unresolved_expressions.append(import_expression)
 
     warnings = _handle_unresolved_import_expressions(
         unresolved_expressions,
@@ -70,7 +71,7 @@ def remove_ignored_imports(
 
 
 def _handle_unresolved_import_expressions(
-    expressions: set[ImportExpression], alert_level: AlertLevel
+    expressions: list[ImportExpression], alert_level: AlertLevel
 ) -> list[str]:
     """
     Handle any unresolved import expressions based on the supplied alert level.

--- a/tests/unit/application/test_contract_utils.py
+++ b/tests/unit/application/test_contract_utils.py
@@ -116,7 +116,7 @@ class TestRemoveIgnoredImports:
                 unmatched_alerting=alert_level,
             )
             assert graph.count_imports() == 1  # The three matching imports have been removed.
-            assert set(warnings) == set(expected_result)
+            assert warnings == expected_result
 
     def _build_graph(self, direct_imports):
         graph = ImportGraph()

--- a/tests/unit/application/test_contract_utils.py
+++ b/tests/unit/application/test_contract_utils.py
@@ -75,7 +75,8 @@ class TestRemoveIgnoredImports:
             (
                 AlertLevel.ERROR,
                 MissingImport(
-                    "No matches for ignored import mypackage.* -> mypackage.nonexistent."
+                    "No matches for ignored import mypackage.* -> mypackage.nonexistent.\n"
+                    "No matches for ignored import mypackage.nonexistent -> mypackage.blue."
                 ),
             ),
         ],

--- a/tests/unit/application/test_contract_utils.py
+++ b/tests/unit/application/test_contract_utils.py
@@ -72,16 +72,11 @@ class TestRemoveIgnoredImports:
                     "No matches for ignored import mypackage.nonexistent -> mypackage.blue.",
                 ],
             ),
-            (
-                AlertLevel.ERROR,
-                MissingImport(
-                    "No matches for ignored import mypackage.* -> mypackage.nonexistent.\n"
-                    "No matches for ignored import mypackage.nonexistent -> mypackage.blue."
-                ),
-            ),
         ],
     )
-    def test_unresolved_import_expressions(self, alert_level, expected_result):
+    def test_unresolved_import_expressions_with_non_error_level_alerting(
+        self, alert_level, expected_result
+    ):
         graph = self._build_graph(self.DIRECT_IMPORTS)
         ignore_imports = [
             ImportExpression(
@@ -102,21 +97,47 @@ class TestRemoveIgnoredImports:
             ),
         ]
 
-        if isinstance(expected_result, Exception):
-            with pytest.raises(type(expected_result), match=str(expected_result)):
-                remove_ignored_imports(
-                    graph=graph,
-                    ignore_imports=ignore_imports,
-                    unmatched_alerting=alert_level,
-                )
-        else:
-            warnings = remove_ignored_imports(
+        warnings = remove_ignored_imports(
+            graph=graph,
+            ignore_imports=ignore_imports,
+            unmatched_alerting=alert_level,
+        )
+        assert graph.count_imports() == 1  # The three matching imports have been removed.
+        assert warnings == expected_result
+
+    def test_unresolved_import_expressions_with_error_level_alerting(self):
+        graph = self._build_graph(self.DIRECT_IMPORTS)
+
+        expected_result = MissingImport(
+            "No matches for ignored import mypackage.* -> mypackage.nonexistent.\n"
+            "No matches for ignored import mypackage.nonexistent -> mypackage.blue."
+        )
+
+        ignore_imports = [
+            ImportExpression(
+                importer=ModuleExpression("mypackage.green"),
+                imported=ModuleExpression("mypackage.blue"),
+            ),
+            ImportExpression(
+                importer=ModuleExpression("mypackage.*"),
+                imported=ModuleExpression("mypackage.nonexistent"),
+            ),
+            ImportExpression(
+                importer=ModuleExpression("mypackage.green"),
+                imported=ModuleExpression("mypackage.purple"),
+            ),
+            ImportExpression(
+                importer=ModuleExpression("mypackage.nonexistent"),
+                imported=ModuleExpression("mypackage.blue"),
+            ),
+        ]
+
+        with pytest.raises(MissingImport, match=str(expected_result)):
+            remove_ignored_imports(
                 graph=graph,
                 ignore_imports=ignore_imports,
-                unmatched_alerting=alert_level,
+                unmatched_alerting=AlertLevel.ERROR,
             )
-            assert graph.count_imports() == 1  # The three matching imports have been removed.
-            assert warnings == expected_result
 
     def _build_graph(self, direct_imports):
         graph = ImportGraph()


### PR DESCRIPTION
Closes #315 

Before this change, whenever a contract had many `n` import ignores that had no matches, users would have to run import-linter `n` times to discover all of them.

This is counter-productive when `n` is big, and what I had to do personally before was delete the list of ignores, run `import-linter` again and let it tell me which ones I should add back.

With this change, we now report all the ignored imports that had no matches in the same run.

- [x] Add tests for the change.
- [x]  Add any appropriate documentation.
- [x]  Run `just check`.
- [x]  Add a summary of changes to `docs/release_notes.md`.
- [x]  Add your name to `docs/authors.md` (in alphabetical order).