### PR TITLE
Fix KeyError when --contract is used with toml config lacking ids

### DIFF
--- a/src/importlinter/application/use_cases.py
+++ b/src/importlinter/application/use_cases.py
@@ -308,8 +308,11 @@ def _filter_contract_options(
     contracts_options: list[dict[str, Any]], limit_to_contracts: tuple[str, ...]
 ) -> list[dict[str, Any]]:
     if limit_to_contracts:
-        # Validate the supplied contract ids.
-        registered_contract_ids = {option["id"] for option in contracts_options}
+        # Validate the supplied contract ids. Contracts without an "id" key can't be
+        # matched by name (this happens with toml configs, where ids are optional), so
+        # they fall through to the "Could not find contract" error below instead of
+        # raising KeyError.
+        registered_contract_ids = {option["id"] for option in contracts_options if "id" in option}
         missing_contract_ids = set(limit_to_contracts) - registered_contract_ids
         if missing_contract_ids:
             if len(missing_contract_ids) == 1:
@@ -326,7 +329,7 @@ def _filter_contract_options(
                     "contracts with those ids."
                 )
         else:
-            return [o for o in contracts_options if o["id"] in limit_to_contracts]
+            return [o for o in contracts_options if o.get("id") in limit_to_contracts]
     else:
         return contracts_options
 

--- a/tests/unit/application/test_use_cases.py
+++ b/tests/unit/application/test_use_cases.py
@@ -647,6 +647,27 @@ class TestCreateReport:
                 limit_to_contracts=limit_to_contracts,
             )
 
+    def test_raises_could_not_find_error_when_contracts_lack_id(self):
+        # Toml configs don't require contract ids. If `--contract` is passed and some
+        # contracts lack an id, we should fall through to the normal "Could not find
+        # contract" error instead of raising KeyError. Regression test for #314.
+        settings.configure(GRAPH_BUILDER=FakeGraphBuilder())
+
+        with pytest.raises(
+            ValueError,
+            match=re.escape("Could not find contract 'foo'."),
+        ):
+            create_report(
+                user_options=UserOptions(
+                    session_options={"root_packages": ["mypackage"]},
+                    contracts_options=[
+                        {"type": "always_passes", "name": "Contract one"},
+                        {"type": "always_passes", "name": "Contract two"},
+                    ],
+                ),
+                limit_to_contracts=("foo",),
+            )
+
 
 class TestReadUserOptions:
     @pytest.mark.parametrize("filename", [".importlinter", "setup.cfg", "foo", "foo.bar"])


### PR DESCRIPTION
## Summary

Fixes #314. `lint-imports --config=importlinter.toml --contract=foo` crashed with `KeyError: 'id'` when any contract in the toml file lacked an explicit id. In ini configs the section syntax forces an id, but in toml the id is optional, and `_filter_contract_options` assumed all contracts had one.

## Changes

`src/importlinter/application/use_cases.py`:
- Build `registered_contract_ids` by skipping contracts without an `"id"` key, instead of raising `KeyError`.
- Use `o.get("id")` when filtering `contracts_options` by `limit_to_contracts` so contracts without an id fall through cleanly.

After the fix, a `--contract` name that doesn't match any contract (including because all contracts lack ids) falls through to the existing `Could not find contract '...'` `ValueError`, which is what the issue asks for.

## Tests

Added a regression test in `tests/unit/application/test_use_cases.py::TestCreateReport::test_raises_could_not_find_error_when_contracts_lack_id` that:
- Supplies two contracts, neither with an `id`.
- Calls `create_report(limit_to_contracts=("foo",))`.
- Asserts the `Could not find contract 'foo'` `ValueError` (not `KeyError`).

All existing `test_use_cases.py` tests still pass (32 passed locally).

Fixes #314

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
