### PR TITLE
Skip self-pairs in forbidden contracts so wildcards can include the source

### DIFF
--- a/docs/authors.md
+++ b/docs/authors.md
@@ -30,5 +30,6 @@
 * [Peter Byfield](https://github.com/Peter554)
 * [Petter Friberg](https://github.com/flaeppe)
 * [piglei](https://github.com/piglei)
+* [Sebastian Penhouet](https://github.com/Spenhouet)
 * [Trevin Chow](https://github.com/tmchow)
 * [Uberto Barbini](https://github.com/uberto)

--- a/docs/contract_types/forbidden.md
+++ b/docs/contract_types/forbidden.md
@@ -11,6 +11,15 @@ checked, not their descendants.
 
 External packages may also be forbidden.
 
+If a source module and a forbidden module refer to the same module (or, when treated as packages,
+one contains the other), that pair is skipped rather than reported, since a module cannot be
+forbidden from importing itself. This means a wildcard such as `mypackage.*` can be used as a
+forbidden module even when a source module is one of the modules it matches. For example, to
+enforce that `mypackage.core` may import only itself and external packages, set
+`source_modules = mypackage.core` and `forbidden_modules = mypackage.*`: the `mypackage.core` ->
+`mypackage.core` pair is skipped, and any newly added sibling package is covered automatically
+without editing the contract.
+
 **Examples:**
 
 === "INI"

--- a/docs/contract_types/forbidden.md
+++ b/docs/contract_types/forbidden.md
@@ -11,16 +11,21 @@ checked, not their descendants.
 
 External packages may also be forbidden.
 
-If a source module and a forbidden module refer to the same module (or, when treated as packages,
-one contains the other), that pair is skipped rather than reported, since a module cannot be
-forbidden from importing itself. This means a wildcard such as `mypackage.*` can be used as a
-forbidden module even when a source module is one of the modules it matches. For example, to
-enforce that `mypackage.core` may import only itself and external packages, set
-`source_modules = mypackage.core` and `forbidden_modules = mypackage.*`: the `mypackage.core` ->
-`mypackage.core` pair is skipped, and any newly added sibling package is covered automatically
-without editing the contract.
+## Overlapping modules
 
-**Examples:**
+Contracts may define `source_modules` and `forbidden_modules` that 'overlap':
+either the same module is in both; or one module is a subpackage that contains the other.
+This is handled differently depending on the value of `as_packages`:
+
+- When `as_packages` is `True` (the default), the source module is allowed to import the forbidden module **if they share descendants**. For example,
+`mypackage.one` will *not* be forbidden from importing `mypackage.one.blue`, or `mypackage.one` itself, even if
+those modules are listed in `forbidden_modules`.
+- When `as_packages` is `False`, a source module **is allowed to import itself**, even if it's listed in forbidden modules.  For example, a source module
+`mypackage.one` will *not* be forbidden `mypackage.one`, even if those modules are listed in `forbidden_modules`.
+
+This situation is most likely to occur when using wildcards.
+
+## Examples
 
 === "INI"
 
@@ -41,6 +46,29 @@ without editing the contract.
     ignore_imports =
       mypackage.one.green -> mypackage.utils
       mypackage.two -> mypackage.four
+
+    [importlinter:contract:forbidden-siblings]
+    # This contract prevents mypackage.one from importing
+    # anything from its siblings.
+    name = Forbidden descendants contract
+    type = forbidden
+    source_modules =
+      mypackage.one
+    forbidden_modules =
+      mypackage.*
+
+    [importlinter:contract:forbidden-descendants]
+    # This contract prevents mypackage.one from importing
+    # anything from its descendants.
+    # Note as_packages must be false, otherwise this contract would have no effect
+    # due to the rules around overlapping modules.
+    name = Forbidden descendants contract
+    type = forbidden
+    source_modules =
+      mypackage.one
+    forbidden_modules =
+      mypackage.one.**
+    as_packages = false
     ```
 
     ```ini
@@ -83,6 +111,33 @@ without editing the contract.
         "mypackage.one.green -> mypackage.utils",
         "mypackage.two -> mypackage.four",
     ]
+    
+    [[tool.importlinter.contracts]]
+    # This contract prevents mypackage.one from importing
+    # anything from its siblings.
+    name = "Forbidden siblings contract"
+    type = "forbidden"
+    source_modules = [
+      "mypackage.one",
+    ]
+    forbidden_modules = [
+      "mypackage.*",
+    ]
+
+    [[tool.importlinter.contracts]]
+    # This contract prevents mypackage.one from importing
+    # anything from its descendants.
+    # Note as_packages must be False, otherwise this contract would have no effect
+    # due to the rules around overlapping modules.
+    name = "Forbidden descendants contract"
+    type = "forbidden"
+    source_modules = [
+      "mypackage.one",
+    ]
+    forbidden_modules = [
+      "mypackage.one.**",
+    ]
+    as_packages = False
     ```
 
     ```toml

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -4,10 +4,7 @@
 
 * Improve error message when root package is a single-file module.
 * Alert users with all unmatched ignored imports in the same run.
-* Forbidden contracts: skip any source/forbidden pair that refers to the same module (or, as
-  packages, one containing the other) instead of raising, so a wildcard such as `mypackage.*` can
-  be used as a forbidden module even when a source module is one of the modules it matches.
-  https://github.com/seddonym/import-linter/issues/360
+* Allow overlapping modules in forbidden contracts.
 
 ## 2.11 (2026-03-06)
 

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -4,6 +4,10 @@
 
 * Improve error message when root package is a single-file module.
 * Alert users with all unmatched ignored imports in the same run.
+* Forbidden contracts: skip any source/forbidden pair that refers to the same module (or, as
+  packages, one containing the other) instead of raising, so a wildcard such as `mypackage.*` can
+  be used as a forbidden module even when a source module is one of the modules it matches.
+  https://github.com/seddonym/import-linter/issues/360
 
 ## 2.11 (2026-03-06)
 

--- a/src/importlinter/contracts/forbidden.py
+++ b/src/importlinter/contracts/forbidden.py
@@ -17,15 +17,35 @@ from importlinter.domain.imports import Module
 from ._common import format_line_numbers
 
 
+def _modules_overlap(
+    source_module: Module, forbidden_module: Module, *, as_packages: bool
+) -> bool:
+    """
+    Return whether the source and forbidden modules overlap: either they are the same module, or,
+    when treated as packages, one contains the other.
+
+    Overlapping pairs do not describe a forbiddable import and are skipped by the contract. See the
+    forbidden contract documentation for details.
+    """
+    if source_module == forbidden_module:
+        return True
+    if as_packages:
+        return source_module.is_in_package(forbidden_module) or forbidden_module.is_in_package(
+            source_module
+        )
+    return False
+
+
 class ForbiddenContract(Contract):
     """
     Forbidden contracts check that one set of modules are not imported by another set of modules.
     Indirect imports will also be checked.
 
-    Any pair where the source and forbidden module are the same (or, when treated as packages, one
-    contains the other) is skipped rather than treated as a violation, since a module cannot be
-    forbidden from importing itself. This means a wildcard such as ``mypackage.*`` can be used as a
-    forbidden module even when a source module is one of the modules it matches.
+    Where the source and forbidden modules overlap (the same module is in both, or one is a
+    subpackage containing the other), the source module is not forbidden from importing the
+    forbidden module; such pairs are skipped. This allows a wildcard such as ``mypackage.*`` to be
+    used as a forbidden module even when a source module is one of the modules it matches. See the
+    documentation for details.
 
     Configuration options:
         - source_modules:    A set of Modules that should not import the forbidden modules.
@@ -87,11 +107,14 @@ class ForbiddenContract(Contract):
 
         for source_module in sorted(source_modules, key=sort_key):
             for forbidden_module in sorted(forbidden_modules_in_graph, key=sort_key):
-                if self._modules_overlap(source_module, forbidden_module):
+                if _modules_overlap(
+                    source_module,
+                    forbidden_module,
+                    as_packages=self.as_packages,  # type: ignore
+                ):
                     output.verbose_print(
                         verbose,
-                        f"Skipping {source_module} -> {forbidden_module} "
-                        "(a module cannot be forbidden from importing itself).",
+                        f"Skipping overlapping modules {source_module} and {forbidden_module}.",
                     )
                     continue
                 output.verbose_print(
@@ -193,24 +216,6 @@ class ForbiddenContract(Contract):
         for module in modules:
             if module.name not in graph.modules:
                 raise ValueError(f"Module '{module.name}' does not exist.")
-
-    def _modules_overlap(self, source_module: Module, forbidden_module: Module) -> bool:
-        """
-        Return whether the source and forbidden modules refer to the same module or, when treated
-        as packages, one contains the other.
-
-        Such a pair cannot describe a forbidden import, since a module cannot be forbidden from
-        importing itself. Skipping these pairs allows a wildcard such as ``mypackage.*`` to be used
-        as a forbidden module even when the source module is one of the matched modules, instead of
-        failing because the source and forbidden modules share descendants.
-        """
-        if source_module == forbidden_module:
-            return True
-        if self.as_packages:
-            return source_module.is_in_package(forbidden_module) or forbidden_module.is_in_package(
-                source_module
-            )
-        return False
 
     def _check_external_forbidden_modules(self, forbidden_modules) -> None:
         external_forbidden_modules = self._get_external_forbidden_modules(forbidden_modules)

--- a/src/importlinter/contracts/forbidden.py
+++ b/src/importlinter/contracts/forbidden.py
@@ -22,6 +22,11 @@ class ForbiddenContract(Contract):
     Forbidden contracts check that one set of modules are not imported by another set of modules.
     Indirect imports will also be checked.
 
+    Any pair where the source and forbidden module are the same (or, when treated as packages, one
+    contains the other) is skipped rather than treated as a violation, since a module cannot be
+    forbidden from importing itself. This means a wildcard such as ``mypackage.*`` can be used as a
+    forbidden module even when a source module is one of the modules it matches.
+
     Configuration options:
         - source_modules:    A set of Modules that should not import the forbidden modules.
         - forbidden_modules: A set of Modules that should not be imported by the source modules.
@@ -82,6 +87,13 @@ class ForbiddenContract(Contract):
 
         for source_module in sorted(source_modules, key=sort_key):
             for forbidden_module in sorted(forbidden_modules_in_graph, key=sort_key):
+                if self._modules_overlap(source_module, forbidden_module):
+                    output.verbose_print(
+                        verbose,
+                        f"Skipping {source_module} -> {forbidden_module} "
+                        "(a module cannot be forbidden from importing itself).",
+                    )
+                    continue
                 output.verbose_print(
                     verbose,
                     f"Searching for import chains from {source_module} to {forbidden_module}...",
@@ -181,6 +193,24 @@ class ForbiddenContract(Contract):
         for module in modules:
             if module.name not in graph.modules:
                 raise ValueError(f"Module '{module.name}' does not exist.")
+
+    def _modules_overlap(self, source_module: Module, forbidden_module: Module) -> bool:
+        """
+        Return whether the source and forbidden modules refer to the same module or, when treated
+        as packages, one contains the other.
+
+        Such a pair cannot describe a forbidden import, since a module cannot be forbidden from
+        importing itself. Skipping these pairs allows a wildcard such as ``mypackage.*`` to be used
+        as a forbidden module even when the source module is one of the matched modules, instead of
+        failing because the source and forbidden modules share descendants.
+        """
+        if source_module == forbidden_module:
+            return True
+        if self.as_packages:
+            return source_module.is_in_package(forbidden_module) or forbidden_module.is_in_package(
+                source_module
+            )
+        return False
 
     def _check_external_forbidden_modules(self, forbidden_modules) -> None:
         external_forbidden_modules = self._get_external_forbidden_modules(forbidden_modules)

--- a/tests/unit/contracts/test_forbidden.py
+++ b/tests/unit/contracts/test_forbidden.py
@@ -450,6 +450,47 @@ class TestForbiddenContract:
         assert "mypackage.one" not in forbidden
 
     @pytest.mark.parametrize(
+        "source_module, forbidden_module",
+        [
+            ("mypackage.one", "mypackage.one.alpha"),
+            ("mypackage.one.alpha", "mypackage.one"),
+        ],
+    )
+    def test_overlapping_modules_treated_as_packages_are_skipped(
+        self, source_module: str, forbidden_module: str
+    ):
+        graph = self._build_graph()
+        contract = self._build_contract(
+            source_modules=(source_module,),
+            forbidden_modules=(forbidden_module,),
+            as_packages=True,
+        )
+
+        contract_check = contract.check(graph=graph, verbose=False)
+
+        assert contract_check.kept
+
+    def test_overlapping_modules_not_treated_as_packages_are_still_checked(self):
+        graph = ImportGraph()
+        for module in ("mypackage", "mypackage.one", "mypackage.one.alpha"):
+            graph.add_module(module)
+        graph.add_import(
+            importer="mypackage.one",
+            imported="mypackage.one.alpha",
+            line_number=1,
+            line_contents="from . import alpha",
+        )
+        contract = self._build_contract(
+            source_modules=("mypackage.one",),
+            forbidden_modules=("mypackage.one.alpha",),
+            as_packages=False,
+        )
+
+        contract_check = contract.check(graph=graph, verbose=False)
+
+        assert not contract_check.kept
+
+    @pytest.mark.parametrize(
         "as_packages, forbidden_modules, expected_invalid_chains",
         [
             (

--- a/tests/unit/contracts/test_forbidden.py
+++ b/tests/unit/contracts/test_forbidden.py
@@ -409,6 +409,46 @@ class TestForbiddenContract:
             ],
         }
 
+    @pytest.mark.parametrize("as_packages", ("False", "True"))
+    def test_source_module_equal_to_forbidden_module_is_skipped(self, as_packages: bool):
+        graph = self._build_graph()
+        contract = self._build_contract(
+            source_modules=("mypackage.one",),
+            forbidden_modules=("mypackage.one",),
+            as_packages=as_packages,
+        )
+
+        contract_check = contract.check(graph=graph, verbose=False)
+
+        assert contract_check.kept
+
+    def test_wildcard_forbidding_source_module_skips_self_and_keeps_unrelated_source(self):
+        graph = self._build_graph()
+        contract = self._build_contract(
+            source_modules=("mypackage.blue",),
+            forbidden_modules=("mypackage.*",),
+        )
+
+        contract_check = contract.check(graph=graph, verbose=False)
+
+        assert contract_check.kept
+
+    def test_wildcard_forbidding_source_module_still_detects_sibling_imports(self):
+        graph = self._build_graph()
+        contract = self._build_contract(
+            source_modules=("mypackage.one",),
+            forbidden_modules=("mypackage.*",),
+        )
+
+        contract_check = contract.check(graph=graph, verbose=False)
+
+        assert not contract_check.kept
+        forbidden = {
+            chain["upstream_module"] for chain in contract_check.metadata["invalid_chains"]
+        }
+        assert "mypackage.green" in forbidden
+        assert "mypackage.one" not in forbidden
+
     @pytest.mark.parametrize(
         "as_packages, forbidden_modules, expected_invalid_chains",
         [


### PR DESCRIPTION
Closes #360.

## Problem

A `forbidden` contract is the natural way to enforce that a package is a leaf, i.e. it may import only itself (and external libraries) and none of its sibling packages, while siblings may still import it. The obvious config is:

```toml
[[tool.importlinter.contracts]]
type = "forbidden"
source_modules = ["mypackage.core"]
forbidden_modules = ["mypackage.*"]
```

But `mypackage.*` also matches `mypackage.core` itself, and the check fails with:

```
Modules have shared descendants.
```

because the `mypackage.core -> mypackage.core` pair is passed to `find_shortest_chains`. `ignore_imports` does not help: it removes edges from the graph, not the module from the expanded forbidden set, so the self-pair is still evaluated. The only workarounds today are enumerating every sibling by hand (and keeping the list in sync as packages are added) or writing a custom contract type.

## Change

In `ForbiddenContract.check`, skip any (source, forbidden) pair that refers to the same module, or, when treated as packages, where one contains the other. A module cannot be meaningfully forbidden from importing itself, so skipping is the correct semantics rather than an error. This lets a wildcard such as `mypackage.*` be used as a forbidden module even when a source module is one of the modules it matches, and newly added sibling packages are covered automatically.

The guard runs before both the direct and indirect (`allow_indirect_imports`) code paths, so neither raises nor reports intra-package imports for the skipped pair.

## Tests

Added unit tests in `tests/unit/contracts/test_forbidden.py`:

- source module equal to a forbidden module is skipped (kept), for `as_packages` True and False
- a wildcard that matches the source module skips the self-pair and keeps an otherwise-clean source
- a wildcard that matches the source module still detects real imports to sibling packages

## Docs

- Documented the behavior on the forbidden contract page, with the leaf-package example.
- Added a release note and an authors entry.

Per CONTRIBUTING, this follows up the filed issue #360; happy to adjust the approach (e.g. an opt-in flag, or an exclusion syntax in module expressions) if you'd prefer a different direction.