### PR TITLE
Add --no-logo flag

### DIFF
--- a/docs/authors.md
+++ b/docs/authors.md
@@ -15,6 +15,7 @@
 * [Daniele Esposti](https://github.com/expobrain)
 * [Fabian Binz](https://github.com/fbinz)
 * [Felix Uhl](https://github.com/iFreilicht)
+* [Felix Schneider](https://github.com/nf3lix)
 * [Ilya S. (Tapeline)](https://github.com/Tapeline)
 * [James Owen](https://github.com/leamingrad)
 * [Jan Bielecki](https://github.com/K4liber)

--- a/docs/get_started/run.md
+++ b/docs/get_started/run.md
@@ -26,6 +26,8 @@ lint-imports
   Disable caching. See [Caching](../caching.md). (Optional.)
 - `--show-timings`:
   Display the times taken to build the graph and check each contract. (Optional.)
+- `--no-logo`:
+  Hide the project logo at startup. (Optional.)
 - `--verbose`:
   Noisily output progress as it goes along. (Optional.)
 - `--version`:

--- a/docs/get_started/run.md
+++ b/docs/get_started/run.md
@@ -27,7 +27,7 @@ lint-imports
 - `--show-timings`:
   Display the times taken to build the graph and check each contract. (Optional.)
 - `--no-logo`:
-  Hide the project logo at startup. (Optional.)
+  Hide the logo at startup. (Optional.)
 - `--verbose`:
   Noisily output progress as it goes along. (Optional.)
 - `--version`:

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -2,7 +2,7 @@
 
 ## latest
 
-* Add `--no-logo` option to hide the project logo in terminal output. 
+* Add `--no-logo` option to hide the logo in terminal output.
 
 ## 2.13 (2026-07-03)
 

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -1,5 +1,9 @@
 # Release notes
 
+## latest
+
+* Add `--no-logo` option to hide the project logo in terminal output. 
+
 ## 2.13 (2026-07-03)
 
 * Add module counts option to the explore UI and `drawgraph` command.

--- a/src/importlinter/application/use_cases.py
+++ b/src/importlinter/application/use_cases.py
@@ -54,7 +54,7 @@ def lint_imports(
                             not swallowed at the top level, so the stack trace can be seen.
         show_timings:       whether to show the times taken to build the graph and to check
                             each contract.
-        no_logo:            if True, the project logo is hidden at startup.
+        no_logo:            if True, the logo is hidden at startup.
         verbose:            if True, noisily output progress as it goes along.
 
     Returns:

--- a/src/importlinter/application/use_cases.py
+++ b/src/importlinter/application/use_cases.py
@@ -38,6 +38,7 @@ def lint_imports(
     cache_dir: str | None | type[NotSupplied] = NotSupplied,
     is_debug_mode: bool = False,
     show_timings: bool = False,
+    no_logo: bool = False,
     verbose: bool = False,
 ) -> bool:
     """
@@ -53,12 +54,14 @@ def lint_imports(
                             not swallowed at the top level, so the stack trace can be seen.
         show_timings:       whether to show the times taken to build the graph and to check
                             each contract.
+        no_logo:            if True, the project logo is hidden at startup.
         verbose:            if True, noisily output progress as it goes along.
 
     Returns:
         True if the linting passed, False if it didn't.
     """
-    rendering.print_title()
+    if not no_logo:
+        rendering.print_title()
 
     output.verbose_print(verbose, "Verbose mode.")
     try:

--- a/src/importlinter/cli.py
+++ b/src/importlinter/cli.py
@@ -33,7 +33,7 @@ def check_options(f):
     f = click.option(
         "--no-logo",
         is_flag=True,
-        help="Hide the project logo at startup.",
+        help="Hide the logo at startup.",
     )(f)
     f = click.option("--debug", is_flag=True, help="Run in debug mode.")(f)
     f = click.option("--no-cache", is_flag=True, help="Disable caching.")(f)
@@ -181,7 +181,7 @@ def lint_imports(
                             not swallowed at the top level, so the stack trace can be seen.
         show_timings:       whether to show the times taken to build the graph and to check
                             each contract.
-        no_logo:            if True, the project logo is hidden at startup.
+        no_logo:            if True, the logo is hidden at startup.
         verbose:            if True, noisily output progress as it goes along.
 
     Returns:

--- a/src/importlinter/cli.py
+++ b/src/importlinter/cli.py
@@ -30,6 +30,11 @@ def check_options(f):
         is_flag=True,
         help="Show times taken to build the graph and to check each contract.",
     )(f)
+    f = click.option(
+        "--no-logo",
+        is_flag=True,
+        help="Hide the project logo at startup.",
+    )(f)
     f = click.option("--debug", is_flag=True, help="Run in debug mode.")(f)
     f = click.option("--no-cache", is_flag=True, help="Disable caching.")(f)
     f = click.option("--cache-dir", default=None, help="The directory to use for caching.")(f)
@@ -50,6 +55,7 @@ def _run_check(
     no_cache: bool,
     debug: bool,
     show_timings: bool,
+    no_logo: bool,
     verbose: bool,
 ) -> None:
     exit_code = lint_imports(
@@ -59,6 +65,7 @@ def _run_check(
         no_cache=no_cache,
         is_debug_mode=debug,
         show_timings=show_timings,
+        no_logo=no_logo,
         verbose=verbose,
     )
     sys.exit(exit_code)
@@ -157,6 +164,7 @@ def lint_imports(
     no_cache: bool = False,
     is_debug_mode: bool = False,
     show_timings: bool = False,
+    no_logo: bool = False,
     verbose: bool = False,
 ) -> int:
     """
@@ -173,6 +181,7 @@ def lint_imports(
                             not swallowed at the top level, so the stack trace can be seen.
         show_timings:       whether to show the times taken to build the graph and to check
                             each contract.
+        no_logo:            if True, the project logo is hidden at startup.
         verbose:            if True, noisily output progress as it goes along.
 
     Returns:
@@ -191,6 +200,7 @@ def lint_imports(
         cache_dir=combined_cache_dir,
         is_debug_mode=is_debug_mode,
         show_timings=show_timings,
+        no_logo=no_logo,
         verbose=verbose,
     )
 

--- a/tests/functional/test_lint_imports.py
+++ b/tests/functional/test_lint_imports.py
@@ -120,6 +120,11 @@ def test_show_timings_smoke_test():
     assert cli.EXIT_STATUS_SUCCESS == cli.lint_imports(show_timings=True)
 
 
+def test_no_logo_smoke_test():
+    os.chdir(testpackage_directory)
+    assert cli.EXIT_STATUS_SUCCESS == cli.lint_imports(no_logo=True)
+
+
 @pytest.mark.parametrize("verbose", (True, False))
 def test_logging_configuration_respects_verbose_flag(verbose, capsys):
     os.chdir(testpackage_directory)

--- a/tests/unit/application/test_use_cases.py
+++ b/tests/unit/application/test_use_cases.py
@@ -272,6 +272,33 @@ class TestCheckContractsAndPrintReport:
             """
         )
 
+    def test_no_logo(self):
+        self._configure(
+            contracts_options=[
+                {"type": "always_passes", "name": "Contract foo"},
+                {"type": "always_passes", "name": "Contract bar"},
+            ]
+        )
+
+        with console.capture() as capture:
+            lint_imports(no_logo=True)
+
+        assert capture.get() == dedent(
+            """\
+            ---------
+            Contracts
+            ---------
+
+            Analyzed 26 files, 10 dependencies.
+            -----------------------------------
+
+            Contract foo KEPT
+            Contract bar KEPT
+
+            Contracts: 2 kept, 0 broken.
+            """
+        )
+
     @pytest.mark.parametrize(
         "cache_dir, expected_graph_building_output",
         (


### PR DESCRIPTION
This adds a CLI flag that allows you to optionally hide the project logo in the terminal. This makes the output a bit less verbose, which can be beneficial for CI/CD logs or AI agents, for example (as mentioned here: https://github.com/seddonym/import-linter/issues/364

- [x] Add tests for the change.
- [x] Add any appropriate documentation.
- [x] Run `just check`.
- [x] Add a summary of changes to `docs/release_notes.md`.
- [x] Add your name to `docs/authors.md` (in alphabetical order).

