### PR TITLE
Clarify protected external

### DIFF
--- a/docs/contract_types/forbidden.md
+++ b/docs/contract_types/forbidden.md
@@ -9,7 +9,7 @@ By default, descendants of each module will be checked - so if `mypackage.one` i
 descendant behaviour can be changed by setting `as_packages` to `False`: in that case, only explicitly listed modules will be
 checked, not their descendants.
 
-External packages may also be forbidden.
+External packages may also be forbidden.  (Be sure to [configure Import Linter to include external packages](../get_started/configure.md#top-level-configuration)).
 
 ## Overlapping modules
 

--- a/docs/contract_types/protected.md
+++ b/docs/contract_types/protected.md
@@ -8,6 +8,8 @@ By default, descendants of each module will be checked too.
 For example, if `blue` is protected, and `green` is the only module in the allow list,
 then no module other than `green` (and its descendants) will be allowed to import `blue` (and its descendants) directly.
 
+External packages may also be protected. (Be sure to [configure Import Linter to include external packages](../get_started/configure.md#top-level-configuration)).
+
 **Examples:**
 
 === "INI"
@@ -41,6 +43,18 @@ then no module other than `green` (and its descendants) will be allowed to impor
         mypackage.one.green -> mypackage.one.models
         mypackage.colors.red.foo -> mypackage.three.models
     as_packages = False
+    ```
+
+    ```ini
+    [importlinter]
+    root_package = mypackage
+    include_external_packages = True
+    
+    [importlinter:contract:protected-boto]
+    name = Boto can only be imported by mypackage.allowed
+    type = protected
+    protected_modules = boto
+    allowed_importers = mypackage.allowed
     ```
 
 === "TOML"
@@ -80,6 +94,18 @@ then no module other than `green` (and its descendants) will be allowed to impor
         "mypackage.colors.red.foo -> mypackage.three.models",
     ]
     as_packages = false
+    ```
+
+    ```toml
+    [tool.importlinter]
+    root_package = "mypackage"
+    include_external_packages = true
+    
+    [[tool.importlinter.contracts]]
+    name = "Boto can only be imported by mypackage.allowed"
+    type = "protected"
+    protected_modules = ["boto"]
+    allowed_importers = ["mypackage.allowed"]
     ```
 
 **Configuration options**


### PR DESCRIPTION
Improve the documentation around handling of external packages in forbidden contracts.

As requested in https://github.com/seddonym/import-linter/issues/367.

Also adds a cross reference from the forbidden contract to the configuration page.

# Screenshot

<img width="1656" height="730" alt="image" src="https://github.com/user-attachments/assets/895a977d-b8bf-4715-88a8-ba159a792bb5" />

# Code snippet

<img width="1570" height="478" alt="image" src="https://github.com/user-attachments/assets/bf2495db-7857-403c-ada6-da2bc08c0779" />


