### PR TITLE
Add broken contract guidance

### DIFF
--- a/docs/contract_types/index.md
+++ b/docs/contract_types/index.md
@@ -70,6 +70,48 @@ If none of the built in contract types meets your needs, you can define a custom
     - `warn`: Print a warning for each unmatched expression.
     - `none`: Do not alert.
 
+- `broken_contract_guidance`: Optional lines of text explaining how to fix the contract. If the contract is broken, these are
+  displayed after its violations. Use this to signpost the right way to do something, so whoever broke the contract
+  doesn't have to read the contract definition to find out.
+
+    This is particularly useful when migrating from one system to another: a contract can forbid the old system
+    while pointing at the new one, so the reader knows what to do instead of adding another entry to the
+    `ignore_imports` burndown list.
+
+    ```toml
+    [[tool.importlinter.contracts]]
+    name = "Colors should not use the legacy numbers API"
+    type = "forbidden"
+    source_modules = ["mypackage.colors"]
+    forbidden_modules = ["mypackage.legacy.numbers"]
+    broken_contract_guidance = """
+    Use mypackage.numbers instead - it's the supported top-level interface.
+    Migration guide: https://docs.example.com/numbers-migration
+    """
+    ```
+
+    ```ini
+    [importlinter:contract:no-legacy-colors]
+    name = Colors should not use the legacy numbers API
+    type = forbidden
+    source_modules =
+        mypackage.colors
+    forbidden_modules =
+        mypackage.legacy.numbers
+    broken_contract_guidance =
+        Use mypackage.numbers instead - it's the supported top-level interface.
+        Migration guide: https://docs.example.com/numbers-migration
+    ```
+
+    When this contract is broken, the output ends with:
+
+    ```
+    Use mypackage.numbers instead - it's the supported top-level interface.
+    Migration guide: https://docs.example.com/numbers-migration
+    ```
+
+    Each line is displayed as written, so any formatting (such as bullets) is up to you.
+
 ## Wildcards
 
 Many contract fields refer to sets of modules - some (but not all) of these support wildcards.

--- a/docs/contract_types/index.md
+++ b/docs/contract_types/index.md
@@ -70,26 +70,9 @@ If none of the built in contract types meets your needs, you can define a custom
     - `warn`: Print a warning for each unmatched expression.
     - `none`: Do not alert.
 
-- `broken_contract_guidance`: Optional lines of text explaining how to fix the contract. If the contract is broken, these are
-  displayed after its violations. Use this to signpost the right way to do something, so whoever broke the contract
-  doesn't have to read the contract definition to find out.
+- `broken_contract_guidance`: A message for Import Linter to display when the contract is broken, below the built-in message. (Optional.) 
 
-    This is particularly useful when migrating from one system to another: a contract can forbid the old system
-    while pointing at the new one, so the reader knows what to do instead of adding another entry to the
-    `ignore_imports` burndown list.
-
-    ```toml
-    [[tool.importlinter.contracts]]
-    name = "Colors should not use the legacy numbers API"
-    type = "forbidden"
-    source_modules = ["mypackage.colors"]
-    forbidden_modules = ["mypackage.legacy.numbers"]
-    broken_contract_guidance = """
-    Use mypackage.numbers instead - it's the supported top-level interface.
-    Migration guide: https://docs.example.com/numbers-migration
-    """
-    ```
-
+=== "INI"
     ```ini
     [importlinter:contract:no-legacy-colors]
     name = Colors should not use the legacy numbers API
@@ -103,14 +86,18 @@ If none of the built in contract types meets your needs, you can define a custom
         Migration guide: https://docs.example.com/numbers-migration
     ```
 
-    When this contract is broken, the output ends with:
-
-    ```
+=== "TOML"
+    ```toml
+    [[tool.importlinter.contracts]]
+    name = "Colors should not use the legacy numbers API"
+    type = "forbidden"
+    source_modules = ["mypackage.colors"]
+    forbidden_modules = ["mypackage.legacy.numbers"]
+    broken_contract_guidance = """
     Use mypackage.numbers instead - it's the supported top-level interface.
     Migration guide: https://docs.example.com/numbers-migration
+    """
     ```
-
-    Each line is displayed as written, so any formatting (such as bullets) is up to you.
 
 ## Wildcards
 

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -2,6 +2,7 @@
 
 ## latest
 
+* Add `broken_contract_guidance` option to contracts, for explaining how to fix them when they're broken.
 * Add `TextField` for multi-line text configuration values.
 * Show the count of ignored imports next to a contract's result.
 * Add `--no-logo` option to hide the logo in terminal output.

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -2,6 +2,7 @@
 
 ## latest
 
+* Add `TextField` for multi-line text configuration values.
 * Show the count of ignored imports next to a contract's result.
 * Add `--no-logo` option to hide the logo in terminal output.
 

--- a/src/importlinter/application/contract_utils.py
+++ b/src/importlinter/application/contract_utils.py
@@ -2,10 +2,11 @@ import enum
 from collections.abc import Sequence
 from dataclasses import dataclass
 
-
-from importlinter.domain.helpers import MissingImport
-from importlinter.domain.imports import ImportExpression, DirectImport, Module
 from grimp import ImportGraph
+
+from importlinter.application import output
+from importlinter.domain.helpers import MissingImport
+from importlinter.domain.imports import DirectImport, ImportExpression, Module
 
 
 class AlertLevel(enum.Enum):
@@ -109,6 +110,23 @@ def remove_ignored_imports_and_report(
         removed_imports=frozenset(imports_to_remove),
         warnings=tuple(resolved_warnings),
     )
+
+
+def render_broken_contract_guidance(broken_contract_guidance: str | None) -> None:
+    """
+    Output any guidance for fixing a broken contract.
+
+    Intended to be called at the end of a contract's render_broken_contract method.
+
+    Args:
+        broken_contract_guidance: Guidance supplied by whoever defined the contract.
+                                  If there isn't any, nothing is rendered.
+    """
+    if not broken_contract_guidance:
+        return
+
+    output.print(broken_contract_guidance)
+    output.new_line()
 
 
 # Private functions

--- a/src/importlinter/contracts/acyclic_siblings.py
+++ b/src/importlinter/contracts/acyclic_siblings.py
@@ -41,6 +41,7 @@ class AcyclicSiblingsContract(Contract):
     skip_descendants = fields.SetField(subfield=fields.ModuleExpressionField(), required=False)
     ignore_imports = fields.SetField(subfield=fields.ImportExpressionField(), required=False)
     unmatched_ignore_imports_alerting = fields.EnumField(AlertLevel, default=AlertLevel.ERROR)
+    broken_contract_guidance = fields.TextField(required=False)
 
     def check(self, graph: grimp.ImportGraph, verbose: bool) -> ContractCheck:
         self._check_no_ancestors_and_descendant_expressions_are_the_same()
@@ -209,3 +210,5 @@ class AcyclicSiblingsContract(Contract):
             if num_extra:
                 output.print_error(f"(and {num_extra} more).")
             output.new_line()
+
+        contract_utils.render_broken_contract_guidance(self.broken_contract_guidance)  # type: ignore

--- a/src/importlinter/contracts/forbidden.py
+++ b/src/importlinter/contracts/forbidden.py
@@ -62,6 +62,9 @@ class ForbiddenContract(Contract):
                              False, each of the modules passed in will be treated as a module
                              rather than a package. Default behaviour is True (treat modules as
                              packages).
+        - broken_contract_guidance:      Guidance explaining how to fix the contract if it's
+                             broken. These are displayed after the contract's violations.
+                             (Optional.)
     """
 
     type_name = "forbidden"
@@ -72,6 +75,7 @@ class ForbiddenContract(Contract):
     allow_indirect_imports = fields.BooleanField(required=False, default=False)
     unmatched_ignore_imports_alerting = fields.EnumField(AlertLevel, default=AlertLevel.ERROR)
     as_packages = fields.BooleanField(required=False, default=True)
+    broken_contract_guidance = fields.TextField(required=False)
 
     def check(self, graph: ImportGraph, verbose: bool) -> ContractCheck:
         is_kept = True
@@ -210,6 +214,8 @@ class ForbiddenContract(Contract):
                 output.new_line()
 
             output.new_line()
+
+        contract_utils.render_broken_contract_guidance(self.broken_contract_guidance)  # type: ignore
 
     def _check_all_modules_exist_in_graph(
         self, modules: Iterable[Module], graph: ImportGraph

--- a/src/importlinter/contracts/independence.py
+++ b/src/importlinter/contracts/independence.py
@@ -43,6 +43,8 @@ class IndependenceContract(Contract):
         - unmatched_ignore_imports_alerting: Decides how to report when the expression in the
                           `ignore_imports` set is not found in the graph. Valid values are
                           "none", "warn", "error". Default value is "error".
+        - broken_contract_guidance:   Guidance explaining how to fix the contract if it's broken.
+                          These are displayed after the contract's violations. (Optional.)
     """
 
     type_name = "independence"
@@ -50,6 +52,7 @@ class IndependenceContract(Contract):
     modules = fields.SetField(subfield=fields.ModuleExpressionField())
     ignore_imports = fields.SetField(subfield=fields.ImportExpressionField(), required=False)
     unmatched_ignore_imports_alerting = fields.EnumField(AlertLevel, default=AlertLevel.ERROR)
+    broken_contract_guidance = fields.TextField(required=False)
 
     def check(self, graph: ImportGraph, verbose: bool) -> ContractCheck:
         import_removal = contract_utils.remove_ignored_imports_and_report(
@@ -88,6 +91,8 @@ class IndependenceContract(Contract):
                 output.new_line()
 
             output.new_line()
+
+        contract_utils.render_broken_contract_guidance(self.broken_contract_guidance)  # type: ignore
 
     def _check_all_modules_exist_in_graph(self, graph: ImportGraph, modules) -> None:
         for module in modules:

--- a/src/importlinter/contracts/layers.py
+++ b/src/importlinter/contracts/layers.py
@@ -119,6 +119,9 @@ class LayersContract(Contract):
                               its list of layers to check. (Optional, default False.)
         - exhaustive_ignores: A set of potential layers to ignore in exhaustiveness checks.
                               (Optional.)
+        - broken_contract_guidance:       Guidance explaining how to fix the contract if it's
+                              broken. These are displayed after the contract's violations.
+                              (Optional.)
     """
 
     type_name = "layers"
@@ -129,6 +132,7 @@ class LayersContract(Contract):
     unmatched_ignore_imports_alerting = fields.EnumField(AlertLevel, default=AlertLevel.ERROR)
     exhaustive = fields.BooleanField(default=False)
     exhaustive_ignores = fields.SetField(subfield=fields.StringField(), required=False)
+    broken_contract_guidance = fields.TextField(required=False)
 
     def validate(self) -> None:
         if self.exhaustive and not self.containers:
@@ -208,6 +212,8 @@ class LayersContract(Contract):
                 "container must be declared as a layer.)"
             )
             output.new_line()
+
+        contract_utils.render_broken_contract_guidance(self.broken_contract_guidance)  # type: ignore
 
     def _validate_containers(self, graph: grimp.ImportGraph, containers: set[str]) -> None:
         root_package_names = self.session_options["root_packages"]

--- a/src/importlinter/contracts/protected.py
+++ b/src/importlinter/contracts/protected.py
@@ -27,6 +27,9 @@ class ProtectedContract(Contract):
                                 False, each of the modules passed in will be treated as a module
                                 rather than a package. Default behaviour is True (treat modules as
                                 packages).
+        - broken_contract_guidance:         Guidance explaining how to fix the contract if it's
+                                broken. These are displayed after the contract's violations.
+                                (Optional.)
     """
 
     type_name = "protected"
@@ -40,6 +43,8 @@ class ProtectedContract(Contract):
     )
 
     as_packages = fields.BooleanField(required=False, default=True)
+
+    broken_contract_guidance = fields.TextField(required=False)
 
     def check(self, graph: grimp.ImportGraph, verbose: bool) -> ContractCheck:
         import_removal = contract_utils.remove_ignored_imports_and_report(
@@ -148,6 +153,8 @@ class ProtectedContract(Contract):
                 )
                 output.new_line()
         output.new_line()
+
+        contract_utils.render_broken_contract_guidance(self.broken_contract_guidance)  # type: ignore
 
 
 @dataclass

--- a/src/importlinter/domain/fields.py
+++ b/src/importlinter/domain/fields.py
@@ -73,6 +73,17 @@ class StringField(Field[str]):
         return str(raw_data)
 
 
+class TextField(Field[str]):
+    """
+    A field for text that may span multiple lines.
+    """
+
+    def parse(self, raw_data: str | list) -> str:
+        if isinstance(raw_data, list):
+            return "\n".join(raw_data)
+        return raw_data
+
+
 class BooleanField(Field[bool]):
     """
     A field for single values of booleans.

--- a/tests/assets/testpackage/.brokencontractguidance.ini
+++ b/tests/assets/testpackage/.brokencontractguidance.ini
@@ -1,0 +1,13 @@
+[importlinter]
+root_package = testpackage
+
+[importlinter:contract:one]
+name=Expected broken contract with broken_contract_guidance
+; This should fail, as high.blue.one -> utils -> high.green.
+type=independence
+modules=
+    testpackage.high.blue
+    testpackage.high.green
+broken_contract_guidance=
+    Use the testpackage.high top-level interface.
+    More information here: http://docs.example.com/high

--- a/tests/functional/test_lint_imports.py
+++ b/tests/functional/test_lint_imports.py
@@ -1,14 +1,14 @@
+import io
 import os
-
 import sys
 from pathlib import Path
 from unittest.mock import patch
+
 import pytest
 from click.testing import CliRunner
 
 from importlinter import __version__, cli
 from importlinter.application import output
-import io
 
 this_directory = Path(__file__).parent
 assets_directory = this_directory / ".." / "assets"
@@ -91,6 +91,17 @@ def test_lint_imports(working_directory, config_filename, expected_result):
         result = cli.lint_imports()
 
     assert expected_result == result
+
+
+def test_lint_imports_renders_broken_contract_guidance_for_broken_contract(capsys):
+    os.chdir(testpackage_directory)
+
+    result = cli.lint_imports(config_filename=".brokencontractguidance.ini")
+
+    assert cli.EXIT_STATUS_ERROR == result
+    captured = capsys.readouterr()
+    assert "Use the testpackage.high top-level interface." in captured.out
+    assert "More information here: http://docs.example.com/high" in captured.out
 
 
 def test_lint_imports_raises_clear_error_when_root_package_is_single_file(capsys):

--- a/tests/unit/contracts/test_acyclic_siblings.py
+++ b/tests/unit/contracts/test_acyclic_siblings.py
@@ -318,6 +318,7 @@ def _build_contract(
     skip_descendants: list[str] | None = None,
     depth: str = "",
     ignore_imports: list[str] | None = None,
+    broken_contract_guidance: str | None = None,
 ) -> AcyclicSiblingsContract:
     contract_options: dict[str, list[str] | str] = {"ancestors": ancestors or ["pkg"]}
     if skip_descendants:
@@ -326,6 +327,8 @@ def _build_contract(
         contract_options["depth"] = depth
     if ignore_imports:
         contract_options["ignore_imports"] = ignore_imports
+    if broken_contract_guidance:
+        contract_options["broken_contract_guidance"] = broken_contract_guidance
     return AcyclicSiblingsContract(
         name="My contract",
         session_options={"root_packages": ["pkg"]},
@@ -381,6 +384,46 @@ class TestVerbosePrint:
 
 
 class TestRenderBrokenContract:
+    def test_render_broken_contract_guidance(self):
+        contract = _build_contract(
+            broken_contract_guidance="Break the cycle via pkg.interfaces.\nMore info: http://docs/cycles"
+        )
+        check = ContractCheck(
+            kept=False,
+            metadata={
+                "summaries": {
+                    PackageSummary(
+                        package="pkg",
+                        dependencies=frozenset(
+                            {
+                                Dependency(
+                                    downstream="pkg.foo",
+                                    upstream="pkg.bar",
+                                    num_imports=10,
+                                ),
+                            }
+                        ),
+                    ),
+                },
+            },
+        )
+
+        with console.capture() as capture:
+            contract.render_broken_contract(check)
+
+        assert capture.get() == dedent(
+            """\
+            No cycles are allowed in pkg.
+            It could be made acyclic by removing 1 dependency:
+
+            - .foo -> .bar (10 imports)
+
+            Break the cycle via pkg.interfaces.
+            More info: http://docs/cycles
+
+            """
+        )
+
     def test_render(self):
         contract = _build_contract()
         check = ContractCheck(

--- a/tests/unit/contracts/test_forbidden.py
+++ b/tests/unit/contracts/test_forbidden.py
@@ -973,6 +973,77 @@ def test_render_broken_contract():
     )
 
 
+@pytest.mark.parametrize(
+    "broken_contract_guidance, expected_broken_contract_guidance_output",
+    (
+        (
+            "Use the mypackage.blue interface.\nMore info: http://docs/blue",
+            "Use the mypackage.blue interface.\nMore info: http://docs/blue\n\n",
+        ),
+        # A single line, as supplied by a single-line INI value.
+        (
+            "Use the mypackage.blue interface.",
+            "Use the mypackage.blue interface.\n\n",
+        ),
+        # Unconfigured and empty guidance should both render nothing.
+        (None, ""),
+        ("", ""),
+    ),
+)
+def test_render_broken_contract_guidance(
+    broken_contract_guidance, expected_broken_contract_guidance_output
+):
+    contract_options = {
+        "source_modules": ("mypackage.one",),
+        "forbidden_modules": ("mypackage.blue",),
+    }
+    if broken_contract_guidance is not None:
+        contract_options["broken_contract_guidance"] = broken_contract_guidance
+
+    contract = ForbiddenContract(
+        name="Forbid contract",
+        session_options={"root_packages": ["mypackage"]},
+        contract_options=contract_options,
+    )
+    check = ContractCheck(
+        kept=False,
+        metadata={
+            "invalid_chains": [
+                {
+                    "upstream_module": "mypackage.blue",
+                    "downstream_module": "mypackage.one",
+                    "chains": [
+                        [
+                            {
+                                "importer": "mypackage.one",
+                                "imported": "mypackage.blue",
+                                "line_numbers": (3,),
+                            }
+                        ]
+                    ],
+                },
+            ]
+        },
+    )
+
+    with console.capture() as capture:
+        contract.render_broken_contract(check)
+
+    assert (
+        capture.get()
+        == dedent(
+            """\
+        mypackage.one is not allowed to import mypackage.blue:
+
+        -   mypackage.one -> mypackage.blue (l.3)
+
+
+        """
+        )
+        + expected_broken_contract_guidance_output
+    )
+
+
 class TestVerbosePrint:
     def test_verbose(self):
         timer = FakeTimer()

--- a/tests/unit/contracts/test_independence.py
+++ b/tests/unit/contracts/test_independence.py
@@ -528,6 +528,57 @@ def test_ignore_imports_adds_warnings():
     }
 
 
+def test_render_broken_contract_guidance():
+    contract = IndependenceContract(
+        name="Independence contract",
+        session_options={"root_packages": ["mypackage"]},
+        contract_options={
+            "modules": ["mypackage.blue", "mypackage.green"],
+            "broken_contract_guidance": "Use the mypackage.blue interface.\nMore info: http://docs/blue",
+        },
+    )
+    check = ContractCheck(
+        kept=False,
+        metadata={
+            "invalid_chains": [
+                {
+                    "upstream_module": "mypackage.green",
+                    "downstream_module": "mypackage.blue",
+                    "chains": [
+                        {
+                            "chain": [
+                                {
+                                    "importer": "mypackage.blue.foo",
+                                    "imported": "mypackage.green.bar",
+                                    "line_numbers": (5,),
+                                },
+                            ],
+                            "extra_firsts": [],
+                            "extra_lasts": [],
+                        }
+                    ],
+                },
+            ]
+        },
+    )
+
+    with console.capture() as capture:
+        contract.render_broken_contract(check)
+
+    assert capture.get() == dedent(
+        """\
+        mypackage.blue is not allowed to import mypackage.green:
+
+        - mypackage.blue.foo -> mypackage.green.bar (l.5)
+
+
+        Use the mypackage.blue interface.
+        More info: http://docs/blue
+
+        """
+    )
+
+
 def test_render_broken_contract():
     contract = IndependenceContract(
         name="Independence contract",

--- a/tests/unit/contracts/test_layers.py
+++ b/tests/unit/contracts/test_layers.py
@@ -1342,6 +1342,59 @@ def test_missing_containerless_layers_raise_value_error():
         contract.check(graph=graph, verbose=False)
 
 
+def test_render_broken_contract_guidance():
+    contract = LayersContract(
+        name="Layers contract",
+        session_options={"root_packages": ["mypackage"]},
+        contract_options={
+            "containers": ["mypackage"],
+            "layers": ["high", "low"],
+            "broken_contract_guidance": "Use the mypackage.high interface.\nMore info: http://docs/layers",
+        },
+    )
+    check = ContractCheck(
+        kept=False,
+        metadata={
+            "invalid_dependencies": [
+                {
+                    "importer": "mypackage.low",
+                    "imported": "mypackage.high",
+                    "routes": [
+                        {
+                            "chain": [
+                                {
+                                    "importer": "mypackage.low.blue",
+                                    "imported": "mypackage.high.yellow",
+                                    "line_numbers": (6,),
+                                }
+                            ],
+                            "extra_firsts": [],
+                            "extra_lasts": [],
+                        }
+                    ],
+                },
+            ],
+            "undeclared_modules": set(),
+        },
+    )
+
+    with console.capture() as capture:
+        contract.render_broken_contract(check)
+
+    assert capture.get() == dedent(
+        """\
+        mypackage.low is not allowed to import mypackage.high:
+
+        - mypackage.low.blue -> mypackage.high.yellow (l.6)
+
+
+        Use the mypackage.high interface.
+        More info: http://docs/layers
+
+        """
+    )
+
+
 def test_render_broken_contract():
     contract = LayersContract(
         name="Layers contract",

--- a/tests/unit/contracts/test_protected.py
+++ b/tests/unit/contracts/test_protected.py
@@ -464,6 +464,46 @@ class TestProtectedContract:
 
         assert contract_check.kept == contract_kept, description
 
+    def test_render_broken_contract_guidance(self):
+        graph = self._build_default_graph()
+
+        graph.add_import(
+            importer="mypackage.foo.sibling",
+            imported="mypackage.foo.protected.models",
+            line_number=6,
+            line_contents="import models",
+        )
+
+        contract = ProtectedContract(
+            name="Protected contract",
+            session_options={
+                "root_packages": ["mypackage"],
+            },
+            contract_options={
+                "protected_modules": ("mypackage.foo.protected"),
+                "allowed_importers": ("mypackage.bar.allowed"),
+                "as_packages": "True",
+                "broken_contract_guidance": "Use the mypackage.foo interface.\nMore info: http://docs/protected",
+            },
+        )
+        contract_check = contract.check(graph=graph, verbose=False)
+
+        with console.capture() as capture:
+            contract.render_broken_contract(contract_check)
+
+        assert not contract_check.kept
+        assert capture.get() == dedent(
+            """Illegal imports of protected package mypackage.foo.protected:
+
+- mypackage.foo.sibling -> mypackage.foo.protected.models (l.6)
+
+
+Use the mypackage.foo interface.
+More info: http://docs/protected
+
+        """
+        )
+
     def test_render_broken_contract_simple_with_package(self):
         graph = self._build_default_graph()
 

--- a/tests/unit/contracts/test_protected.py
+++ b/tests/unit/contracts/test_protected.py
@@ -493,15 +493,16 @@ class TestProtectedContract:
 
         assert not contract_check.kept
         assert capture.get() == dedent(
-            """Illegal imports of protected package mypackage.foo.protected:
+            """\
+            Illegal imports of protected package mypackage.foo.protected:
 
-- mypackage.foo.sibling -> mypackage.foo.protected.models (l.6)
+            - mypackage.foo.sibling -> mypackage.foo.protected.models (l.6)
 
 
-Use the mypackage.foo interface.
-More info: http://docs/protected
+            Use the mypackage.foo interface.
+            More info: http://docs/protected
 
-        """
+            """
         )
 
     def test_render_broken_contract_simple_with_package(self):
@@ -532,12 +533,13 @@ More info: http://docs/protected
 
         assert not contract_check.kept
         assert capture.get() == dedent(
-            """Illegal imports of protected package mypackage.foo.protected:
+            """\
+            Illegal imports of protected package mypackage.foo.protected:
 
-- mypackage.foo.sibling -> mypackage.foo.protected.models (l.6)
+            - mypackage.foo.sibling -> mypackage.foo.protected.models (l.6)
 
 
-        """
+            """
         )
 
     def test_render_broken_contract_full_with_package(self):
@@ -639,31 +641,32 @@ More info: http://docs/protected
             contract.render_broken_contract(contract_check)
 
         assert capture.get() == dedent(
-            """Illegal imports of protected package mypackage.blue.models
-(via mypackage.**.models expression):
+            """\
+            Illegal imports of protected package mypackage.blue.models
+            (via mypackage.**.models expression):
 
-- mypackage.green.one -> mypackage.blue.models (l.7)
+            - mypackage.green.one -> mypackage.blue.models (l.7)
 
-- mypackage.green.three -> mypackage.blue.models (l.12, 34)
+            - mypackage.green.three -> mypackage.blue.models (l.12, 34)
 
-- mypackage.green.five -> mypackage.blue.models.alpha (l.4)
+            - mypackage.green.five -> mypackage.blue.models.alpha (l.4)
 
-Illegal imports of protected package mypackage.orange.models
-(via mypackage.**.models expression):
+            Illegal imports of protected package mypackage.orange.models
+            (via mypackage.**.models expression):
 
-- mypackage.yellow.one -> mypackage.orange.models (l.16)
+            - mypackage.yellow.one -> mypackage.orange.models (l.16)
 
-Illegal imports of protected package mypackage.orange.data
-(via mypackage.**.data expression):
+            Illegal imports of protected package mypackage.orange.data
+            (via mypackage.**.data expression):
 
-- mypackage.yellow.one -> mypackage.orange.data (l.17)
+            - mypackage.yellow.one -> mypackage.orange.data (l.17)
 
-Illegal imports of protected package mypackage.brown:
+            Illegal imports of protected package mypackage.brown:
 
-- mypackage.yellow.one -> mypackage.brown (l.18)
+            - mypackage.yellow.one -> mypackage.brown (l.18)
 
-- mypackage.yellow.one -> mypackage.brown.alpha (l.19)
+            - mypackage.yellow.one -> mypackage.brown.alpha (l.19)
 
 
-        """
+            """
         )

--- a/tests/unit/domain/test_fields.py
+++ b/tests/unit/domain/test_fields.py
@@ -1,5 +1,4 @@
 import enum
-
 import re
 from typing import Any
 
@@ -7,14 +6,15 @@ import pytest
 
 from importlinter.domain.fields import (
     BooleanField,
-    IntegerField,
     EnumField,
     Field,
     ImportExpressionField,
+    IntegerField,
     ListField,
     ModuleField,
     SetField,
     StringField,
+    TextField,
     ValidationError,
 )
 from importlinter.domain.imports import ImportExpression, Module, ModuleExpression
@@ -55,6 +55,20 @@ class BaseFieldTest:
 )
 class TestStringField(BaseFieldTest):
     field_class = StringField
+
+
+@pytest.mark.parametrize(
+    "raw_data, expected_value",
+    (
+        ("Some text.", "Some text."),
+        (
+            ["First paragraph.", "", "Second paragraph."],
+            "First paragraph.\n\nSecond paragraph.",
+        ),
+    ),
+)
+class TestTextField(BaseFieldTest):
+    field_class = TextField
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- Adds optional `broken_contract_guidance` to the five built-in contract types.
  - Guidance appears after a broken contract's violations and can direct the reader to the intended alternative.
- Adds reusable `TextField` support for multi-line configuration text.

## Broken contract guidance

`broken_contract_guidance` lets whoever defines a contract explain how to resolve a failure, so the person whose change broke the contract can see the intended alternative without reading the contract definition.

When a contract with guidance is broken, it is rendered after the violations:

```
testpackage.high.blue is not allowed to import testpackage.high.green:

- testpackage.high.blue.one -> testpackage.utils (l.3)
  testpackage.utils -> testpackage.high.green (l.3)

Use the testpackage.high top-level interface.
More information here: http://docs.example.com/high
```

One use case is migrating between systems: a contract can forbid the old system while signposting the new one, instead of leaving the reader to add another entry to the `ignore_imports` burndown list.

The field is declared on each built-in contract type, so custom contract types do not receive it for free yet. Making it framework-level would require `_get_field_names()` to walk the MRO; it currently reads `cls.__dict__`.

Custom contracts can still use the contract_utils function to render it.

## TextField

This PR also adds `TextField`, a reusable field for one text value that may span several lines.

- It accepts a normal string, including TOML multiline strings.
- It accepts the list of lines produced by the INI reader.
- It joins INI lines with newlines without discarding blank lines.

That gives contract code a single string while retaining intentional paragraph breaks in INI configuration. `broken_contract_guidance` uses `TextField`; formatting, including bullets and wrapping, is the contract author's choice.

Note: `.ini` and `.toml` don't have the exact same behaviour, we can't start a line with a space in an ini file, whereas we can with toml. 

## Checklist

[x] Add tests for the change.
[x] Add documentation.
[x] Add release notes.

Related to https://github.com/seddonym/import-linter/issues/370
Disclaimer: made with Claude code