### PR TITLE
Document the --debug flag

### DIFF
--- a/docs/authors.md
+++ b/docs/authors.md
@@ -31,6 +31,7 @@
 * [Peter Byfield](https://github.com/Peter554)
 * [Petter Friberg](https://github.com/flaeppe)
 * [piglei](https://github.com/piglei)
+* [Sarmad Ali Chohan](https://github.com/chohan-sarmad-ali)
 * [Sebastian Penhouet](https://github.com/Spenhouet)
 * [Trevin Chow](https://github.com/tmchow)
 * [Uberto Barbini](https://github.com/uberto)

--- a/docs/get_started/run.md
+++ b/docs/get_started/run.md
@@ -24,6 +24,9 @@ lint-imports
   The directory to use for caching. Defaults to `.import_linter_cache`. See [Caching](../caching.md). (Optional.)
 - `--no-cache`:
   Disable caching. See [Caching](../caching.md). (Optional.)
+- `--debug`:
+  Run in debug mode. Exceptions are not swallowed at the top level, so the full stack
+  trace can be seen — useful when investigating or reporting a bug. (Optional.)
 - `--show-timings`:
   Display the times taken to build the graph and check each contract. (Optional.)
 - `--no-logo`:
@@ -59,6 +62,12 @@ Using a different cache directory, or disabling caching
 lint-imports --cache-dir path/to/cache
 
 lint-imports --no-cache
+```
+
+Run in debug mode, showing full stack traces:
+
+```text
+lint-imports --debug
 ```
 
 #### Showing timings

--- a/docs/get_started/run.md
+++ b/docs/get_started/run.md
@@ -64,12 +64,6 @@ lint-imports --cache-dir path/to/cache
 lint-imports --no-cache
 ```
 
-Run in debug mode, showing full stack traces:
-
-```text
-lint-imports --debug
-```
-
 #### Showing timings
 
 ```console
@@ -80,6 +74,14 @@ lint-imports --show-timings
 
 ```console
 lint-imports --verbose
+```
+
+#### Debug mode
+
+Run in debug mode, showing full stack traces:
+
+```text
+lint-imports --debug
 ```
 
 ### Running using pre-commit


### PR DESCRIPTION
Closes #173.

Adds `--debug` to the Options list in `docs/get_started/run.md`, plus a short usage example alongside the other flag examples. Wording follows the `lint_imports` docstring ("exceptions are not swallowed at the top level, so the stack trace can be seen") rather than inventing a description, and the entry sits where the flag sits in the CLI declaration order, next to the cache flags.

Docs-only; no behaviour change.