### PR TITLE
Speed up forbidden contracts with a single batched graph search

### DIFF
--- a/src/importlinter/contracts/_common.py
+++ b/src/importlinter/contracts/_common.py
@@ -12,11 +12,9 @@ import itertools
 from collections.abc import Sequence
 
 import grimp
-from grimp import ImportGraph
 from typing_extensions import TypedDict
 
 from importlinter.application import output
-from importlinter.domain.imports import Module
 
 
 class Link(TypedDict):
@@ -35,6 +33,16 @@ class DetailedChain(TypedDict):
     extra_lasts: list[Link]
 
 
+class ModulePairChains(TypedDict):
+    """
+    The chains found between a single pair of modules.
+    """
+
+    upstream_module: str
+    downstream_module: str
+    chains: list[DetailedChain]
+
+
 def render_chain_data(chain_data: DetailedChain) -> None:
     main_chain = chain_data["chain"]
     _render_direct_import(main_chain[0], extra_firsts=chain_data["extra_firsts"], first_line=True)
@@ -44,105 +52,6 @@ def render_chain_data(chain_data: DetailedChain) -> None:
 
     if len(main_chain) > 1:
         _render_direct_import(main_chain[-1], extra_lasts=chain_data["extra_lasts"])
-
-
-def find_segments(
-    graph: ImportGraph, reference_graph: ImportGraph, importer: Module, imported: Module
-) -> list[Chain]:
-    """
-    Return list of headless and tailless chains.
-
-    Two graphs are passed in: the first is mutated, the second is used purely as a reference to
-    look up import details which are otherwise removed during mutation.
-    """
-    segments = []
-    for chain in _pop_shortest_chains(graph, importer=importer.name, imported=imported.name):
-        if len(chain) == 2:
-            raise ValueError("Direct chain found - these should have been removed.")
-        segment: list[Link] = []
-        for importer_in_chain, imported_in_chain in [
-            (chain[i], chain[i + 1]) for i in range(len(chain) - 1)
-        ]:
-            import_details = reference_graph.get_import_details(
-                importer=importer_in_chain, imported=imported_in_chain
-            )
-            line_numbers = tuple(sorted({j["line_number"] for j in import_details}))
-            segment.append(
-                {
-                    "importer": importer_in_chain,
-                    "imported": imported_in_chain,
-                    "line_numbers": line_numbers,
-                }
-            )
-        segments.append(segment)
-    return segments
-
-
-def segments_to_collapsed_chains(
-    graph: ImportGraph, segments: list[Chain], importer: Module, imported: Module
-) -> list[DetailedChain]:
-    collapsed_chains: list[DetailedChain] = []
-    for segment in segments:
-        head_imports: list[Link] = []
-        imported_module = segment[0]["imported"]
-        candidate_modules = sorted(graph.find_modules_that_directly_import(imported_module))
-        for module in [
-            m
-            for m in candidate_modules
-            if Module(m) == importer or Module(m).is_descendant_of(importer)
-        ]:
-            import_details_list = graph.get_import_details(
-                importer=module, imported=imported_module
-            )
-            line_numbers = tuple(sorted({j["line_number"] for j in import_details_list}))
-            head_imports.append(
-                {
-                    "importer": module,
-                    "imported": imported_module,
-                    "line_numbers": line_numbers,
-                }
-            )
-
-        tail_imports: list[Link] = []
-        importer_module = segment[-1]["importer"]
-        candidate_modules = sorted(graph.find_modules_directly_imported_by(importer_module))
-        for module in [
-            m
-            for m in candidate_modules
-            if Module(m) == imported or Module(m).is_descendant_of(imported)
-        ]:
-            import_details_list = graph.get_import_details(
-                importer=importer_module, imported=module
-            )
-            line_numbers = tuple(sorted({j["line_number"] for j in import_details_list}))
-            tail_imports.append(
-                {
-                    "importer": importer_module,
-                    "imported": module,
-                    "line_numbers": line_numbers,
-                }
-            )
-
-        collapsed_chains.append(
-            {
-                "chain": [head_imports[0]] + segment[1:-1] + [tail_imports[0]],
-                "extra_firsts": head_imports[1:],
-                "extra_lasts": tail_imports[1:],
-            }
-        )
-
-    return collapsed_chains
-
-
-def _pop_shortest_chains(graph: ImportGraph, importer: str, imported: str):
-    chain: tuple[str, ...] | None | bool = True
-    while chain:
-        chain = graph.find_shortest_chain(importer, imported)
-        if chain:
-            # Remove chain of imports from graph.
-            for index in range(len(chain) - 1):
-                graph.remove_import(importer=chain[index], imported=chain[index + 1])
-            yield chain
 
 
 def format_line_numbers(line_numbers: Sequence[int | None]) -> str:
@@ -214,18 +123,40 @@ def build_detailed_chain_from_route(route: grimp.Route, graph: grimp.ImportGraph
         for tail in ordered_tails[1:]
     ]
     chain_as_strings = [ordered_heads[0], *route.middle, ordered_tails[0]]
-    chain_as_links: Chain = [
+    return {
+        "chain": build_chain_from_module_names(chain_as_strings, graph),
+        "extra_firsts": extra_firsts,
+        "extra_lasts": extra_lasts,
+    }
+
+
+def build_chain_from_module_names(module_names: Sequence[str], graph: grimp.ImportGraph) -> Chain:
+    """
+    Return the links between each consecutive pair of the supplied module names.
+    """
+    return [
         {
             "importer": importer,
             "imported": imported,
             "line_numbers": get_line_numbers(importer=importer, imported=imported, graph=graph),
         }
-        for importer, imported in itertools.pairwise(chain_as_strings)
+        for importer, imported in itertools.pairwise(module_names)
     ]
+
+
+def build_detailed_chain_from_module_names(
+    module_names: Sequence[str], graph: grimp.ImportGraph
+) -> DetailedChain:
+    """
+    Return a detailed chain for a chain that was found on its own.
+
+    Chains found individually have no shared heads or tails to collapse, so the extras are
+    always empty; the shape matches the chains built from routes so that both render identically.
+    """
     return {
-        "chain": chain_as_links,
-        "extra_firsts": extra_firsts,
-        "extra_lasts": extra_lasts,
+        "chain": build_chain_from_module_names(module_names, graph),
+        "extra_firsts": [],
+        "extra_lasts": [],
     }
 
 

--- a/src/importlinter/contracts/forbidden.py
+++ b/src/importlinter/contracts/forbidden.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+from operator import attrgetter
 from typing import cast
-from collections.abc import Iterable
+from collections.abc import Iterable, Sequence
 
+import grimp
 from grimp import ImportGraph
 
 from importlinter.application import contract_utils, output
@@ -14,7 +16,55 @@ from importlinter.domain.contract import Contract, ContractCheck
 from importlinter.domain.helpers import module_expressions_to_modules
 from importlinter.domain.imports import Module
 
-from ._common import format_line_numbers
+from ._common import (
+    DetailedChain,
+    ModulePairChains,
+    build_detailed_chain_from_module_names,
+    build_detailed_chain_from_route,
+    render_chain_data,
+)
+
+
+def _chain_sort_key(chain_data: DetailedChain) -> tuple:
+    """
+    Return a sort key that orders chains by the modules they pass through.
+
+    Shorter chains sort first, so the most direct routes are reported first.
+    """
+    links = chain_data["chain"]
+    return (len(links), tuple((link["importer"], link["imported"]) for link in links))
+
+
+def _ancestor_names(module_name: str) -> set[str]:
+    """
+    Return the names of the module's ancestor packages, not including the module itself.
+    """
+    components = module_name.split(".")
+    return {".".join(components[:index]) for index in range(1, len(components))}
+
+
+def _any_modules_overlap(
+    source_modules: Sequence[Module], forbidden_modules: Sequence[Module]
+) -> bool:
+    """
+    Return whether any source module overlaps with any forbidden module, treated as packages.
+
+    Comparing every pair would be O(N * M); because one module can only contain another if it is
+    one of its ancestors, looking the ancestors up in a set is O((N + M) * depth) instead. This
+    runs before every batched search, so the difference is worth having.
+    """
+    source_names = {module.name for module in source_modules}
+    forbidden_names = {module.name for module in forbidden_modules}
+    if source_names & forbidden_names:
+        return True
+    return any(
+        _ancestor_names(name) & other_names
+        for names, other_names in (
+            (source_names, forbidden_names),
+            (forbidden_names, source_names),
+        )
+        for name in names
+    )
 
 
 def _modules_overlap(
@@ -74,9 +124,6 @@ class ForbiddenContract(Contract):
     as_packages = fields.BooleanField(required=False, default=True)
 
     def check(self, graph: ImportGraph, verbose: bool) -> ContractCheck:
-        is_kept = True
-        invalid_chains = []
-
         warnings = contract_utils.remove_ignored_imports(
             graph=graph,
             ignore_imports=self.ignore_imports,  # type: ignore
@@ -102,16 +149,124 @@ class ForbiddenContract(Contract):
         # We only need to check for illegal imports for forbidden modules that are in the graph.
         forbidden_modules_in_graph = [m for m in forbidden_modules if m.name in graph.modules]
 
-        def sort_key(module):
-            return module.name
+        if self._can_use_batched_search(source_modules, forbidden_modules_in_graph):
+            invalid_chains = self._find_invalid_chains_in_one_pass(
+                graph, source_modules, forbidden_modules_in_graph, verbose
+            )
+        else:
+            invalid_chains = self._find_invalid_chains_per_pair(
+                graph, source_modules, forbidden_modules_in_graph, verbose
+            )
 
-        for source_module in sorted(source_modules, key=sort_key):
-            for forbidden_module in sorted(forbidden_modules_in_graph, key=sort_key):
-                if _modules_overlap(
-                    source_module,
-                    forbidden_module,
-                    as_packages=self.as_packages,  # type: ignore
-                ):
+        # Sorting by upstream and downstream module ensures that the output is deterministic
+        # and that the same upstream and downstream modules are always adjacent in the output.
+        return ContractCheck(
+            kept=not invalid_chains,
+            warnings=warnings,
+            metadata={
+                "invalid_chains": sorted(
+                    invalid_chains,
+                    key=lambda data: (data["upstream_module"], data["downstream_module"]),
+                )
+            },
+        )
+
+    def _can_use_batched_search(
+        self, source_modules: Sequence[Module], forbidden_modules: Sequence[Module]
+    ) -> bool:
+        """
+        Return whether this contract can be checked with a single graph search.
+
+        The batched search (see _find_invalid_chains_in_one_pass) is dramatically faster, but it
+        can't express every configuration, so the slower pair-by-pair search remains the fallback.
+        """
+        if not self.as_packages:
+            # Grimp's layers analysis always treats modules as packages.
+            return False
+        if self.allow_indirect_imports:
+            # This option only looks at direct imports, which the layers analysis can't express.
+            return False
+        # Grimp raises if any two modules in different layers overlap. The pair-by-pair search
+        # skips such pairs individually, but a single overlapping pair would invalidate the
+        # whole batch, so any overlap at all sends us down the fallback path.
+        return not _any_modules_overlap(source_modules, forbidden_modules)
+
+    def _find_invalid_chains_in_one_pass(
+        self,
+        graph: ImportGraph,
+        source_modules: Sequence[Module],
+        forbidden_modules: Sequence[Module],
+        verbose: bool,
+    ) -> list[ModulePairChains]:
+        """
+        Return the illegal chains, using a single graph search for every source/forbidden pair.
+
+        A forbidden contract is equivalent to a two-layer architecture: grimp treats a lower
+        layer importing a higher one as illegal, so putting the forbidden modules in the higher
+        layer and the source modules in the lower layer makes exactly the source -> forbidden
+        direction illegal. The layers are non-independent because source modules are free to
+        import each other, as are forbidden modules; only the cross-layer direction matters.
+        """
+        output.verbose_print(
+            verbose,
+            f"Searching for import chains from {len(source_modules)} source module(s) "
+            f"to {len(forbidden_modules)} forbidden module(s)...",
+        )
+        with settings.TIMER as timer:
+            dependencies = graph.find_illegal_dependencies_for_layers(
+                layers=(
+                    grimp.Layer(*(m.name for m in forbidden_modules), independent=False),
+                    grimp.Layer(*(m.name for m in source_modules), independent=False),
+                ),
+            )
+            invalid_chains: list[ModulePairChains] = []
+            for dependency in dependencies:
+                # Routes come back as an unordered set, so sort the chains they produce to keep
+                # the reported output stable between runs.
+                chains: list[DetailedChain] = sorted(
+                    (build_detailed_chain_from_route(route, graph) for route in dependency.routes),
+                    key=_chain_sort_key,
+                )
+                invalid_chains.append(
+                    {
+                        "upstream_module": dependency.imported,
+                        "downstream_module": dependency.importer,
+                        "chains": chains,
+                    }
+                )
+        self._print_chain_count(
+            verbose, sum(len(data["chains"]) for data in invalid_chains), timer
+        )
+        return invalid_chains
+
+    def _print_chain_count(self, verbose: bool, chain_count: int, timer) -> None:
+        if not verbose:
+            return
+        pluralized = "s" if chain_count != 1 else ""
+        duration = rendering.format_duration(timer.duration_in_ms)
+        output.print(f"Found {chain_count} illegal chain{pluralized} in {duration}.")
+
+    def _find_invalid_chains_per_pair(
+        self,
+        graph: ImportGraph,
+        source_modules: Sequence[Module],
+        forbidden_modules_in_graph: Sequence[Module],
+        verbose: bool,
+    ) -> list[ModulePairChains]:
+        """
+        Return the illegal chains, using a separate graph search for each source/forbidden pair.
+
+        This is much slower than _find_invalid_chains_in_one_pass, but it supports the
+        configurations that the batched search can't express.
+        """
+        invalid_chains: list[ModulePairChains] = []
+        as_packages = cast(bool, self.as_packages)
+        allow_indirect_imports = cast(bool, self.allow_indirect_imports)
+        sorted_forbidden_modules = sorted(forbidden_modules_in_graph, key=attrgetter("name"))
+
+        for source_module in sorted(source_modules, key=attrgetter("name")):
+            for forbidden_module in sorted_forbidden_modules:
+                if _modules_overlap(source_module, forbidden_module, as_packages=as_packages):
                     output.verbose_print(
                         verbose,
                         f"Skipping overlapping modules {source_module} and {forbidden_module}.",
@@ -122,67 +277,33 @@ class ForbiddenContract(Contract):
                     f"Searching for import chains from {source_module} to {forbidden_module}...",
                 )
                 with settings.TIMER as timer:
-                    subpackage_chain_data = {
-                        "upstream_module": forbidden_module.name,
-                        "downstream_module": source_module.name,
-                        "chains": [],
-                    }
-
-                    if str(self.allow_indirect_imports).lower() == "true":
+                    if allow_indirect_imports:
                         chains = self._get_direct_chains(
-                            source_module,
-                            forbidden_module,
-                            graph,
-                            self.as_packages,  # type:ignore
+                            source_module, forbidden_module, graph, as_packages
                         )
                     else:
                         chains = graph.find_shortest_chains(
                             importer=source_module.name,
                             imported=forbidden_module.name,
-                            as_packages=self.as_packages,  # type:ignore
+                            as_packages=as_packages,
                         )
-                    if chains:
-                        is_kept = False
-                        for chain in sorted(chains):
-                            chain_data = []
-                            for importer, imported in [
-                                (chain[i], chain[i + 1]) for i in range(len(chain) - 1)
-                            ]:
-                                import_details = graph.get_import_details(
-                                    importer=importer, imported=imported
-                                )
-                                line_numbers = tuple(j["line_number"] for j in import_details)
-                                chain_data.append(
-                                    {
-                                        "importer": importer,
-                                        "imported": imported,
-                                        "line_numbers": line_numbers,
-                                    }
-                                )
-                            subpackage_chain_data["chains"].append(chain_data)  # type: ignore
-                if subpackage_chain_data["chains"]:
-                    invalid_chains.append(subpackage_chain_data)
-                if verbose:
-                    chain_count = len(subpackage_chain_data["chains"])
-                    pluralized = "s" if chain_count != 1 else ""
-                    duration = rendering.format_duration(timer.duration_in_ms)
-                    output.print(
-                        f"Found {chain_count} illegal chain{pluralized} in {duration}.",
+                    detailed_chains = [
+                        build_detailed_chain_from_module_names(chain, graph)
+                        for chain in sorted(chains)
+                    ]
+                if detailed_chains:
+                    invalid_chains.append(
+                        {
+                            "upstream_module": forbidden_module.name,
+                            "downstream_module": source_module.name,
+                            "chains": detailed_chains,
+                        }
                     )
+                self._print_chain_count(verbose, len(detailed_chains), timer)
 
-        # Sorting by upstream and downstream module ensures that the output is deterministic
-        # and that the same upstream and downstream modules are always adjacent in the output.
-        def chain_sort_key(chain_data):
-            return (chain_data["upstream_module"], chain_data["downstream_module"])
-
-        return ContractCheck(
-            kept=is_kept,
-            warnings=warnings,
-            metadata={"invalid_chains": sorted(invalid_chains, key=chain_sort_key)},
-        )
+        return invalid_chains
 
     def render_broken_contract(self, check: ContractCheck) -> None:
-        count = 0
         for chains_data in check.metadata["invalid_chains"]:
             downstream, upstream = (
                 chains_data["downstream_module"],
@@ -190,22 +311,9 @@ class ForbiddenContract(Contract):
             )
             output.print_error(f"{downstream} is not allowed to import {upstream}:")
             output.new_line()
-            count += len(chains_data["chains"])
-            for chain in chains_data["chains"]:
-                first_line = True
-                for direct_import in chain:
-                    importer, imported = (
-                        direct_import["importer"],
-                        direct_import["imported"],
-                    )
-                    line_numbers = format_line_numbers(direct_import["line_numbers"])
-                    import_string = f"{importer} -> {imported} ({line_numbers})"
-                    if first_line:
-                        output.print_error(f"-   {import_string}", bold=False)
-                        first_line = False
-                    else:
-                        output.indent_cursor()
-                        output.print_error(import_string, bold=False)
+
+            for chain_data in chains_data["chains"]:
+                render_chain_data(chain_data)
                 output.new_line()
 
             output.new_line()
@@ -253,32 +361,37 @@ class ForbiddenContract(Contract):
         graph: ImportGraph,
         as_packages: bool,
     ) -> set[tuple[str, ...]]:
-        chains: set[tuple[str, ...]] = set()
-        source_modules = (
-            self._get_all_modules_in_package(source_package, graph)
-            if as_packages
-            else {source_package}
-        )
-        forbidden_modules = (
-            self._get_all_modules_in_package(forbidden_package, graph)
-            if as_packages
-            else {forbidden_package}
-        )
-        for source_module in source_modules:
-            imported_module_names = graph.find_modules_directly_imported_by(source_module.name)
-            for imported_module_name in imported_module_names:
-                imported_module = Module(imported_module_name)
-                if imported_module in forbidden_modules:
-                    chains.add((source_module.name, imported_module.name))
-        return chains
+        """
+        Return the direct imports from the source package to the forbidden package.
 
-    def _get_all_modules_in_package(self, module: Module, graph: ImportGraph) -> set[Module]:
+        The modules of each package are looked up and then walked, rather than matching import
+        expressions, because expression matching scans every import in the graph: its cost grows
+        with the size of the whole graph rather than with the size of the packages, and this runs
+        once per source/forbidden pair.
+        """
+        source_modules = self._get_all_modules_in_package(source_package, graph, as_packages)
+        forbidden_module_names = {
+            module.name
+            for module in self._get_all_modules_in_package(forbidden_package, graph, as_packages)
+        }
+
+        return {
+            (source_module.name, imported_module_name)
+            for source_module in source_modules
+            for imported_module_name in graph.find_modules_directly_imported_by(source_module.name)
+            if imported_module_name in forbidden_module_names
+        }
+
+    def _get_all_modules_in_package(
+        self, module: Module, graph: ImportGraph, as_packages: bool
+    ) -> set[Module]:
         """
         Return all the modules in the supplied module, including itself.
 
-        If the module is squashed, it will be treated as a single module.
+        If the module is squashed, or is not being treated as a package, it will be treated as a
+        single module.
         """
-        importer_modules = {module}
-        if not graph.is_module_squashed(module.name):
-            importer_modules |= {Module(m) for m in graph.find_descendants(module.name)}
-        return importer_modules
+        modules = {module}
+        if as_packages and not graph.is_module_squashed(module.name):
+            modules |= {Module(m) for m in graph.find_descendants(module.name)}
+        return modules

--- a/src/importlinter/contracts/independence.py
+++ b/src/importlinter/contracts/independence.py
@@ -4,27 +4,20 @@ from typing import cast
 
 import grimp
 from grimp import ImportGraph
-from typing_extensions import TypedDict
 
 from importlinter.application import contract_utils, output
 from importlinter.application.contract_utils import AlertLevel
 from importlinter.domain import fields
 from importlinter.domain.contract import Contract, ContractCheck
 from importlinter.domain.helpers import module_expressions_to_modules
-from importlinter.domain.imports import Module
 
 from ._common import (
-    DetailedChain,
-    Link,
+    ModulePairChains,
     build_detailed_chain_from_route,
     render_chain_data,
 )
 
-
-class _SubpackageChainData(TypedDict):
-    upstream_module: str
-    downstream_module: str
-    chains: list[DetailedChain]
+_SubpackageChainData = ModulePairChains
 
 
 class IndependenceContract(Contract):
@@ -104,42 +97,3 @@ class IndependenceContract(Contract):
             }
             for dependency in dependencies
         ]
-
-    def _build_subpackage_chain_data(
-        self, upstream_module: Module, downstream_module: Module, graph: ImportGraph
-    ) -> _SubpackageChainData:
-        """
-        Return any import chains from the upstream to downstream module.
-        """
-        subpackage_chain_data: _SubpackageChainData = {
-            "upstream_module": upstream_module.name,
-            "downstream_module": downstream_module.name,
-            "chains": [],
-        }
-        assert isinstance(subpackage_chain_data["chains"], list)  # For type checker.
-        chains = graph.find_shortest_chains(
-            importer=downstream_module.name, imported=upstream_module.name
-        )
-        if chains:
-            for chain in chains:
-                chain_data: list[Link] = []
-                for importer, imported in [
-                    (chain[i], chain[i + 1]) for i in range(len(chain) - 1)
-                ]:
-                    import_details = graph.get_import_details(importer=importer, imported=imported)
-                    line_numbers = tuple(j["line_number"] for j in import_details)
-                    chain_data.append(
-                        {
-                            "importer": importer,
-                            "imported": imported,
-                            "line_numbers": line_numbers,
-                        }
-                    )
-                detailed_chain: DetailedChain = {
-                    "chain": chain_data,
-                    "extra_firsts": [],
-                    "extra_lasts": [],
-                }
-                subpackage_chain_data["chains"].append(detailed_chain)
-
-        return subpackage_chain_data

--- a/tests/unit/contracts/test_forbidden.py
+++ b/tests/unit/contracts/test_forbidden.py
@@ -6,7 +6,19 @@ from importlinter.application.output import console
 from importlinter.configuration import settings
 from importlinter.contracts.forbidden import ForbiddenContract
 from importlinter.domain.contract import ContractCheck
+from importlinter.domain.imports import Module
 from tests.adapters.timing import FakeTimer
+
+
+def detailed(chain: list[dict]) -> dict:
+    """
+    Wrap a flat chain of imports in the envelope that the contract reports.
+
+    The forbidden contract reports each chain in the same collapsed form as the layers and
+    independence contracts, but it never has shared heads or tails to collapse, so the extras
+    are always empty.
+    """
+    return {"chain": chain, "extra_firsts": [], "extra_lasts": []}
 
 
 @pytest.fixture(scope="module", autouse=True)
@@ -46,51 +58,59 @@ class TestForbiddenContract:
                         "upstream_module": "mypackage.green",
                         "downstream_module": "mypackage.one",
                         "chains": [
-                            [
-                                {
-                                    "importer": "mypackage.one.alpha",
-                                    "imported": "mypackage.green.beta",
-                                    "line_numbers": (3,),
-                                }
-                            ],
-                            [
-                                {
-                                    "importer": "mypackage.one.alpha.circle",
-                                    "imported": "mypackage.green.beta.sphere",
-                                    "line_numbers": (8,),
-                                },
-                            ],
+                            detailed(
+                                [
+                                    {
+                                        "importer": "mypackage.one.alpha",
+                                        "imported": "mypackage.green.beta",
+                                        "line_numbers": (3,),
+                                    }
+                                ]
+                            ),
+                            detailed(
+                                [
+                                    {
+                                        "importer": "mypackage.one.alpha.circle",
+                                        "imported": "mypackage.green.beta.sphere",
+                                        "line_numbers": (8,),
+                                    },
+                                ]
+                            ),
                         ],
                     },
                     {
                         "upstream_module": "mypackage.green",
                         "downstream_module": "mypackage.three",
                         "chains": [
-                            [
-                                {
-                                    "importer": "mypackage.three",
-                                    "imported": "mypackage.green",
-                                    "line_numbers": (4,),
-                                }
-                            ]
+                            detailed(
+                                [
+                                    {
+                                        "importer": "mypackage.three",
+                                        "imported": "mypackage.green",
+                                        "line_numbers": (4,),
+                                    }
+                                ]
+                            )
                         ],
                     },
                     {
                         "upstream_module": "mypackage.purple",
                         "downstream_module": "mypackage.two",
                         "chains": [
-                            [
-                                {
-                                    "importer": "mypackage.two",
-                                    "imported": "mypackage.utils",
-                                    "line_numbers": (9,),
-                                },
-                                {
-                                    "importer": "mypackage.utils",
-                                    "imported": "mypackage.purple",
-                                    "line_numbers": (1,),
-                                },
-                            ]
+                            detailed(
+                                [
+                                    {
+                                        "importer": "mypackage.two",
+                                        "imported": "mypackage.utils",
+                                        "line_numbers": (9,),
+                                    },
+                                    {
+                                        "importer": "mypackage.utils",
+                                        "imported": "mypackage.purple",
+                                        "line_numbers": (1,),
+                                    },
+                                ]
+                            )
                         ],
                     },
                 ],
@@ -108,31 +128,35 @@ class TestForbiddenContract:
                         "upstream_module": "mypackage.green",
                         "downstream_module": "mypackage.three",
                         "chains": [
-                            [
-                                {
-                                    "importer": "mypackage.three",
-                                    "imported": "mypackage.green",
-                                    "line_numbers": (4,),
-                                }
-                            ]
+                            detailed(
+                                [
+                                    {
+                                        "importer": "mypackage.three",
+                                        "imported": "mypackage.green",
+                                        "line_numbers": (4,),
+                                    }
+                                ]
+                            )
                         ],
                     },
                     {
                         "upstream_module": "mypackage.purple",
                         "downstream_module": "mypackage.two",
                         "chains": [
-                            [
-                                {
-                                    "importer": "mypackage.two",
-                                    "imported": "mypackage.utils",
-                                    "line_numbers": (9,),
-                                },
-                                {
-                                    "importer": "mypackage.utils",
-                                    "imported": "mypackage.purple",
-                                    "line_numbers": (1,),
-                                },
-                            ]
+                            detailed(
+                                [
+                                    {
+                                        "importer": "mypackage.two",
+                                        "imported": "mypackage.utils",
+                                        "line_numbers": (9,),
+                                    },
+                                    {
+                                        "importer": "mypackage.utils",
+                                        "imported": "mypackage.purple",
+                                        "line_numbers": (1,),
+                                    },
+                                ]
+                            )
                         ],
                     },
                 ],
@@ -184,13 +208,15 @@ class TestForbiddenContract:
                     "upstream_module": "sqlalchemy",
                     "downstream_module": "mypackage.three",
                     "chains": [
-                        [
-                            {
-                                "importer": "mypackage.three",
-                                "imported": "sqlalchemy",
-                                "line_numbers": (1,),
-                            }
-                        ]
+                        detailed(
+                            [
+                                {
+                                    "importer": "mypackage.three",
+                                    "imported": "sqlalchemy",
+                                    "line_numbers": (1,),
+                                }
+                            ]
+                        )
                     ],
                 }
             ]
@@ -262,20 +288,24 @@ class TestForbiddenContract:
                     "upstream_module": "mypackage.green",
                     "downstream_module": "mypackage.one.alpha",
                     "chains": [
-                        [
-                            {
-                                "importer": "mypackage.one.alpha",
-                                "imported": "mypackage.green.beta",
-                                "line_numbers": (3,),
-                            },
-                        ],
-                        [
-                            {
-                                "importer": "mypackage.one.alpha.circle",
-                                "imported": "mypackage.green.beta.sphere",
-                                "line_numbers": (8,),
-                            },
-                        ],
+                        detailed(
+                            [
+                                {
+                                    "importer": "mypackage.one.alpha",
+                                    "imported": "mypackage.green.beta",
+                                    "line_numbers": (3,),
+                                },
+                            ]
+                        ),
+                        detailed(
+                            [
+                                {
+                                    "importer": "mypackage.one.alpha.circle",
+                                    "imported": "mypackage.green.beta.sphere",
+                                    "line_numbers": (8,),
+                                },
+                            ]
+                        ),
                     ],
                 },
             ],
@@ -296,33 +326,39 @@ class TestForbiddenContract:
                     "upstream_module": "mypackage.green",
                     "downstream_module": "mypackage.one.alpha",
                     "chains": [
-                        [
-                            {
-                                "importer": "mypackage.one.alpha",
-                                "imported": "mypackage.green.beta",
-                                "line_numbers": (3,),
-                            },
-                        ],
-                        [
-                            {
-                                "importer": "mypackage.one.alpha.circle",
-                                "imported": "mypackage.green.beta.sphere",
-                                "line_numbers": (8,),
-                            },
-                        ],
+                        detailed(
+                            [
+                                {
+                                    "importer": "mypackage.one.alpha",
+                                    "imported": "mypackage.green.beta",
+                                    "line_numbers": (3,),
+                                },
+                            ]
+                        ),
+                        detailed(
+                            [
+                                {
+                                    "importer": "mypackage.one.alpha.circle",
+                                    "imported": "mypackage.green.beta.sphere",
+                                    "line_numbers": (8,),
+                                },
+                            ]
+                        ),
                     ],
                 },
                 {
                     "upstream_module": "mypackage.green",
                     "downstream_module": "mypackage.one.alpha.circle",
                     "chains": [
-                        [
-                            {
-                                "importer": "mypackage.one.alpha.circle",
-                                "imported": "mypackage.green.beta.sphere",
-                                "line_numbers": (8,),
-                            },
-                        ],
+                        detailed(
+                            [
+                                {
+                                    "importer": "mypackage.one.alpha.circle",
+                                    "imported": "mypackage.green.beta.sphere",
+                                    "line_numbers": (8,),
+                                },
+                            ]
+                        ),
                     ],
                 },
             ],
@@ -343,20 +379,24 @@ class TestForbiddenContract:
                     "upstream_module": "mypackage.green.beta",
                     "downstream_module": "mypackage.one",
                     "chains": [
-                        [
-                            {
-                                "importer": "mypackage.one.alpha",
-                                "imported": "mypackage.green.beta",
-                                "line_numbers": (3,),
-                            },
-                        ],
-                        [
-                            {
-                                "importer": "mypackage.one.alpha.circle",
-                                "imported": "mypackage.green.beta.sphere",
-                                "line_numbers": (8,),
-                            },
-                        ],
+                        detailed(
+                            [
+                                {
+                                    "importer": "mypackage.one.alpha",
+                                    "imported": "mypackage.green.beta",
+                                    "line_numbers": (3,),
+                                },
+                            ]
+                        ),
+                        detailed(
+                            [
+                                {
+                                    "importer": "mypackage.one.alpha.circle",
+                                    "imported": "mypackage.green.beta.sphere",
+                                    "line_numbers": (8,),
+                                },
+                            ]
+                        ),
                     ],
                 },
             ],
@@ -377,33 +417,39 @@ class TestForbiddenContract:
                     "upstream_module": "mypackage.green.beta",
                     "downstream_module": "mypackage.one",
                     "chains": [
-                        [
-                            {
-                                "importer": "mypackage.one.alpha",
-                                "imported": "mypackage.green.beta",
-                                "line_numbers": (3,),
-                            },
-                        ],
-                        [
-                            {
-                                "importer": "mypackage.one.alpha.circle",
-                                "imported": "mypackage.green.beta.sphere",
-                                "line_numbers": (8,),
-                            },
-                        ],
+                        detailed(
+                            [
+                                {
+                                    "importer": "mypackage.one.alpha",
+                                    "imported": "mypackage.green.beta",
+                                    "line_numbers": (3,),
+                                },
+                            ]
+                        ),
+                        detailed(
+                            [
+                                {
+                                    "importer": "mypackage.one.alpha.circle",
+                                    "imported": "mypackage.green.beta.sphere",
+                                    "line_numbers": (8,),
+                                },
+                            ]
+                        ),
                     ],
                 },
                 {
                     "upstream_module": "mypackage.green.beta.sphere",
                     "downstream_module": "mypackage.one",
                     "chains": [
-                        [
-                            {
-                                "importer": "mypackage.one.alpha.circle",
-                                "imported": "mypackage.green.beta.sphere",
-                                "line_numbers": (8,),
-                            },
-                        ],
+                        detailed(
+                            [
+                                {
+                                    "importer": "mypackage.one.alpha.circle",
+                                    "imported": "mypackage.green.beta.sphere",
+                                    "line_numbers": (8,),
+                                },
+                            ]
+                        ),
                     ],
                 },
             ],
@@ -491,6 +537,89 @@ class TestForbiddenContract:
         assert not contract_check.kept
 
     @pytest.mark.parametrize(
+        "options, expected",
+        [
+            ({}, True),
+            # Grimp's layers analysis always treats modules as packages.
+            ({"as_packages": False}, False),
+            # This option only looks at direct imports.
+            ({"allow_indirect_imports": True}, False),
+        ],
+    )
+    def test_batched_search_is_used_unless_options_prevent_it(self, options: dict, expected: bool):
+        contract = self._build_contract(forbidden_modules=("mypackage.green",), **options)
+
+        assert (
+            contract._can_use_batched_search(
+                [Module("mypackage.one")], [Module("mypackage.green")]
+            )
+            is expected
+        )
+
+    @pytest.mark.parametrize(
+        "source_module, forbidden_module",
+        [
+            # Identical modules.
+            ("mypackage.one", "mypackage.one"),
+            # A source module containing a forbidden module.
+            ("mypackage.one", "mypackage.one.alpha"),
+            # A forbidden module containing a source module.
+            ("mypackage.one.alpha", "mypackage.one"),
+        ],
+    )
+    def test_batched_search_is_not_used_for_overlapping_modules(
+        self, source_module: str, forbidden_module: str
+    ):
+        """
+        Grimp rejects layers that overlap, so any overlapping pair sends the whole contract
+        down the pair-by-pair path, which skips such pairs individually.
+        """
+        contract = self._build_contract(forbidden_modules=(forbidden_module,))
+
+        assert not contract._can_use_batched_search(
+            [Module(source_module)], [Module(forbidden_module)]
+        )
+
+    def test_batched_and_pair_by_pair_searches_agree(self):
+        """
+        The contract has two search strategies: a single batched graph search, and a slower
+        pair-by-pair fallback for the configurations the batched search can't express. They
+        must never disagree about which imports are illegal.
+        """
+        contract = self._build_contract(
+            forbidden_modules=(
+                "mypackage.blue",
+                "mypackage.green",
+                "mypackage.yellow",
+                "mypackage.purple",
+            ),
+        )
+        sources = [Module(m) for m in ("mypackage.one", "mypackage.two", "mypackage.three")]
+        forbidden = [
+            Module(m)
+            for m in (
+                "mypackage.blue",
+                "mypackage.green",
+                "mypackage.yellow",
+                "mypackage.purple",
+            )
+        ]
+        assert contract._can_use_batched_search(sources, forbidden)
+
+        batched = contract._find_invalid_chains_in_one_pass(
+            self._build_graph(), sources, forbidden, verbose=False
+        )
+        pair_by_pair = contract._find_invalid_chains_per_pair(
+            self._build_graph(), sources, forbidden, verbose=False
+        )
+
+        def pairs(invalid_chains):
+            return sorted((c["downstream_module"], c["upstream_module"]) for c in invalid_chains)
+
+        assert pairs(batched) == pairs(pair_by_pair)
+        assert pairs(batched) != []
+
+    @pytest.mark.parametrize(
         "as_packages, forbidden_modules, expected_invalid_chains",
         [
             (
@@ -501,26 +630,30 @@ class TestForbiddenContract:
                         "upstream_module": "mypackage.green",
                         "downstream_module": "mypackage.one",
                         "chains": [
-                            [
-                                {
-                                    "importer": "mypackage.one.alpha.circle",
-                                    "imported": "mypackage.green.beta.sphere",
-                                    "line_numbers": (8,),
-                                },
-                            ]
+                            detailed(
+                                [
+                                    {
+                                        "importer": "mypackage.one.alpha.circle",
+                                        "imported": "mypackage.green.beta.sphere",
+                                        "line_numbers": (8,),
+                                    },
+                                ]
+                            )
                         ],
                     },
                     {
                         "upstream_module": "mypackage.green",
                         "downstream_module": "mypackage.three",
                         "chains": [
-                            [
-                                {
-                                    "importer": "mypackage.three",
-                                    "imported": "mypackage.green",
-                                    "line_numbers": (4,),
-                                },
-                            ]
+                            detailed(
+                                [
+                                    {
+                                        "importer": "mypackage.three",
+                                        "imported": "mypackage.green",
+                                        "line_numbers": (4,),
+                                    },
+                                ]
+                            )
                         ],
                     },
                 ],
@@ -533,13 +666,15 @@ class TestForbiddenContract:
                         "upstream_module": "mypackage.green",
                         "downstream_module": "mypackage.three",
                         "chains": [
-                            [
-                                {
-                                    "importer": "mypackage.three",
-                                    "imported": "mypackage.green",
-                                    "line_numbers": (4,),
-                                },
-                            ]
+                            detailed(
+                                [
+                                    {
+                                        "importer": "mypackage.three",
+                                        "imported": "mypackage.green",
+                                        "line_numbers": (4,),
+                                    },
+                                ]
+                            )
                         ],
                     },
                 ],
@@ -586,13 +721,15 @@ class TestForbiddenContract:
                     "upstream_module": "mypackage.green",
                     "downstream_module": "mypackage.three",
                     "chains": [
-                        [
-                            {
-                                "importer": "mypackage.three",
-                                "imported": "mypackage.green",
-                                "line_numbers": (4,),
-                            }
-                        ]
+                        detailed(
+                            [
+                                {
+                                    "importer": "mypackage.three",
+                                    "imported": "mypackage.green",
+                                    "line_numbers": (4,),
+                                }
+                            ]
+                        )
                     ],
                 },
             ]
@@ -660,9 +797,9 @@ class TestForbiddenContract:
             },
         ]
         if allow_indirect_imports:
-            expected_chains = [direct_chain]
+            expected_chains = [detailed(direct_chain)]
         else:
-            expected_chains = [direct_chain, indirect_chain]
+            expected_chains = [detailed(direct_chain), detailed(indirect_chain)]
         assert contract_check.metadata == {
             "invalid_chains": [
                 {
@@ -922,31 +1059,35 @@ def test_render_broken_contract():
                     "upstream_module": "mypackage.purple",
                     "downstream_module": "mypackage.two",
                     "chains": [
-                        [
-                            {
-                                "importer": "mypackage.two",
-                                "imported": "mypackage.utils",
-                                "line_numbers": (9,),
-                            },
-                            {
-                                "importer": "mypackage.utils",
-                                "imported": "mypackage.purple",
-                                "line_numbers": (1,),
-                            },
-                        ]
+                        detailed(
+                            [
+                                {
+                                    "importer": "mypackage.two",
+                                    "imported": "mypackage.utils",
+                                    "line_numbers": (9,),
+                                },
+                                {
+                                    "importer": "mypackage.utils",
+                                    "imported": "mypackage.purple",
+                                    "line_numbers": (1,),
+                                },
+                            ]
+                        )
                     ],
                 },
                 {
                     "upstream_module": "mypackage.green",
                     "downstream_module": "mypackage.three",
                     "chains": [
-                        [
-                            {
-                                "importer": "mypackage.three",
-                                "imported": "mypackage.green",
-                                "line_numbers": (4,),
-                            }
-                        ]
+                        detailed(
+                            [
+                                {
+                                    "importer": "mypackage.three",
+                                    "imported": "mypackage.green",
+                                    "line_numbers": (4,),
+                                }
+                            ]
+                        )
                     ],
                 },
             ]
@@ -960,13 +1101,13 @@ def test_render_broken_contract():
         """\
         mypackage.two is not allowed to import mypackage.purple:
 
-        -   mypackage.two -> mypackage.utils (l.9)
-            mypackage.utils -> mypackage.purple (l.1)
+        - mypackage.two -> mypackage.utils (l.9)
+          mypackage.utils -> mypackage.purple (l.1)
 
 
         mypackage.three is not allowed to import mypackage.green:
 
-        -   mypackage.three -> mypackage.green (l.4)
+        - mypackage.three -> mypackage.green (l.4)
 
 
         """
@@ -974,11 +1115,8 @@ def test_render_broken_contract():
 
 
 class TestVerbosePrint:
-    def test_verbose(self):
-        timer = FakeTimer()
-        timer.setup(tick_duration=10, increment=0)
-        settings.configure(TIMER=timer)
-
+    @staticmethod
+    def _build_graph() -> ImportGraph:
         graph = ImportGraph()
         for module in (
             "one",
@@ -1023,7 +1161,11 @@ class TestVerbosePrint:
             line_number=1,
             line_contents="foo",
         )
-        contract = ForbiddenContract(
+        return graph
+
+    @staticmethod
+    def _build_contract(**extra_options) -> ForbiddenContract:
+        return ForbiddenContract(
             name="Forbid contract",
             session_options={"root_packages": ["mypackage"]},
             contract_options={
@@ -1036,8 +1178,43 @@ class TestVerbosePrint:
                 ),
                 "ignore_imports": [],
                 "allow_indirect_imports": "false",
+                **extra_options,
             },
         )
+
+    def test_verbose(self):
+        """
+        The batched search covers every source/forbidden pair in a single pass, so it reports
+        once rather than once per pair.
+        """
+        timer = FakeTimer()
+        timer.setup(tick_duration=10, increment=0)
+        settings.configure(TIMER=timer)
+
+        graph = self._build_graph()
+        contract = self._build_contract()
+
+        with console.capture() as capture:
+            contract.check(graph=graph, verbose=True)
+
+        assert capture.get() == dedent(
+            """\
+            Searching for import chains from 3 source module(s) to 4 forbidden module(s)...
+            Found 3 illegal chains in 10s.
+            """
+        )
+
+    def test_verbose_when_falling_back_to_pair_by_pair_search(self):
+        """
+        as_packages=False can't be expressed as a layers analysis, so the contract falls back
+        to searching each source/forbidden pair separately.
+        """
+        timer = FakeTimer()
+        timer.setup(tick_duration=10, increment=0)
+        settings.configure(TIMER=timer)
+
+        graph = self._build_graph()
+        contract = self._build_contract(as_packages="False")
 
         with console.capture() as capture:
             contract.check(graph=graph, verbose=True)
@@ -1047,7 +1224,7 @@ class TestVerbosePrint:
             Searching for import chains from mypackage.one to mypackage.blue...
             Found 0 illegal chains in 10s.
             Searching for import chains from mypackage.one to mypackage.green...
-            Found 1 illegal chain in 10s.
+            Found 0 illegal chains in 10s.
             Searching for import chains from mypackage.one to mypackage.purple...
             Found 0 illegal chains in 10s.
             Searching for import chains from mypackage.one to mypackage.yellow...


### PR DESCRIPTION
Forbidden contracts issued one full graph search per (source, forbidden) pair. With wildcard module expressions both sides expand, so the number of searches was quadratic, and each search is expensive precisely when the contract is broken.

A forbidden contract is expressible as a two-layer architecture: grimp treats a lower layer importing a higher one as illegal, so putting the forbidden modules in the higher layer and the source modules in the lower layer makes exactly the source -> forbidden direction illegal. That is a single find_illegal_dependencies_for_layers call. The layers are non-independent, because source modules are free to import each other, as are forbidden modules; only the cross-layer direction matters.

Measured end-to-end through the contract, on a synthetic 21,041-module / ~100,000-import graph:

    12x12 pairs, violating:  39.21s -> 2.09s  (18.7x)
    24x24 pairs, clean:       0.21s -> 0.03s   (6.2x)

The pair-by-pair search is retained as a fallback for the configurations the batched search cannot express, guarded by three conditions:

  - as_packages=False, since the layers analysis always treats modules as packages;
  - allow_indirect_imports=True, which only looks at direct imports;
  - any overlapping source/forbidden pair, since grimp rejects overlapping layers whereas the pair-by-pair search skips such pairs individually.

The overlap condition is decided by looking each module's ancestors up in a set rather than by comparing every pair, since one module can only contain another if it is one of its ancestors. That keeps the check linear in the number of modules, which matters because it is a fixed cost paid before every batched search.

Broken forbidden contracts now report chains in the same collapsed form as layers and independence contracts, grouping shared heads and tails instead of listing every chain in full. Routes come back from grimp as an unordered set, so the chains they produce are sorted shortest-first to keep output stable between runs.

Both search paths build their chains through _common, which grows build_detailed_chain_from_module_names for chains found on their own. Such chains have no shared heads or tails to collapse, so their extras are empty, but the shape is the same and the two paths render identically. The metadata shape itself moves to _common as ModulePairChains, shared with independence contracts, which lets both of the search methods here be typed rather than returning bare dicts.

Also simplify _get_direct_chains, which tests the imported module names against a set of names rather than constructing a Module for each one, and folds the as_packages branching into _get_all_modules_in_package.

Finally, remove dead code that was the last home of the repeated BFS-plus-mutation pattern: _common.find_segments, _pop_shortest_chains and segments_to_collapsed_chains, along with the leftover IndependenceContract._build_subpackage_chain_data.

[ ] Add tests for the change.
[ ] Add any appropriate documentation.
[ ] Run `just check`.
[ ] Add a summary of changes to `docs/release_notes.md`.
[ ] Add your name to `docs/authors.md` (in alphabetical order).

