### PR TITLE
Show count of ignored imports in contract output (#375)

### DIFF
--- a/docs/authors.md
+++ b/docs/authors.md
@@ -13,6 +13,7 @@
 * [Christoph Gietl](https://github.com/christophgietl)
 * [Daniel Jurczak](https://github.com/danieljurczak)
 * [Daniele Esposti](https://github.com/expobrain)
+* [Diego Impieri](https://github.com/yunusdim)
 * [Fabian Binz](https://github.com/fbinz)
 * [Felix Uhl](https://github.com/iFreilicht)
 * [Felix Schneider](https://github.com/nf3lix)

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -2,6 +2,7 @@
 
 ## latest
 
+* Show the count of ignored imports next to a contract's result, e.g. `KEPT (3 ignored imports)`. Omitted when the count is zero.
 * Add `--no-logo` option to hide the logo in terminal output.
 
 ## 2.13 (2026-07-03)

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -2,7 +2,8 @@
 
 ## latest
 
-* Show the count of ignored imports next to a contract's result, e.g. `KEPT (3 ignored imports)`. Omitted when the count is zero.
+* Show the count of ignored imports next to a contract's result, combined with the warning count into a single clause, e.g. `KEPT (3 ignored imports, 1 warning)`. Either part is omitted when its count is zero.
+* Add `contract_utils.remove_ignored_imports_and_report`, returning a new `ImportRemoval` object (the removed imports and any warnings). `contract_utils.remove_ignored_imports` is deprecated in favour of it and will change its return type in Import Linter 2.15.
 * Add `--no-logo` option to hide the logo in terminal output.
 
 ## 2.13 (2026-07-03)

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -2,8 +2,7 @@
 
 ## latest
 
-* Show the count of ignored imports next to a contract's result, combined with the warning count into a single clause, e.g. `KEPT (3 ignored imports, 1 warning)`. Either part is omitted when its count is zero.
-* Add `contract_utils.remove_ignored_imports_and_report`, returning a new `ImportRemoval` object (the removed imports and any warnings). `contract_utils.remove_ignored_imports` is deprecated in favour of it and will change its return type in Import Linter 2.15.
+* Show the count of ignored imports next to a contract's result.
 * Add `--no-logo` option to hide the logo in terminal output.
 
 ## 2.13 (2026-07-03)

--- a/src/importlinter/application/contract_utils.py
+++ b/src/importlinter/application/contract_utils.py
@@ -1,5 +1,4 @@
 import enum
-import warnings
 from collections.abc import Sequence
 from dataclasses import dataclass
 
@@ -37,12 +36,6 @@ def remove_ignored_imports(
     """
     Remove any ignored imports from the graph.
 
-    Deprecated: this function's return type will change from list[str] to ImportRemoval in
-    Import Linter 2.15. New callers, and existing callers who are able to, should switch to
-    remove_ignored_imports_and_report, which already returns an ImportRemoval today. This
-    function will keep returning a plain list of warnings until that release, but emits a
-    DeprecationWarning as of this release to flag the upcoming change.
-
     Args:
         graph:              The graph that is being checked by a contract.
         ignore_imports:     Any import expressions that indicate imports to ignore.
@@ -54,14 +47,7 @@ def remove_ignored_imports(
     Returns:
         A list of any warnings to be surfaced to the user.
     """
-    warnings.warn(
-        "remove_ignored_imports() will change its return type from list[str] to ImportRemoval "
-        "in Import Linter 2.15. Switch to remove_ignored_imports_and_report(), which already "
-        "returns an ImportRemoval, to be ready ahead of that change.",
-        DeprecationWarning,
-        stacklevel=2,
-    )
-    import_removal = _remove_ignored_imports(graph, ignore_imports, unmatched_alerting)
+    import_removal = remove_ignored_imports_and_report(graph, ignore_imports, unmatched_alerting)
     return list(import_removal.warnings)
 
 
@@ -72,6 +58,9 @@ def remove_ignored_imports_and_report(
 ) -> ImportRemoval:
     """
     Remove any ignored imports from the graph.
+
+    Behaves the same as remove_ignored_imports, except it returns an object
+    with more information about what was removed.
 
     Args:
         graph:              The graph that is being checked by a contract.
@@ -85,18 +74,6 @@ def remove_ignored_imports_and_report(
         An ImportRemoval, containing the DirectImports that were removed from the graph and any
         warnings to be surfaced to the user.
     """
-    return _remove_ignored_imports(graph, ignore_imports, unmatched_alerting)
-
-
-# Private functions
-# -----------------
-
-
-def _remove_ignored_imports(
-    graph: ImportGraph,
-    ignore_imports: Sequence[ImportExpression] | None,
-    unmatched_alerting: AlertLevel,
-) -> ImportRemoval:
     imports_to_remove: set[DirectImport] = set()
     unresolved_expressions = []
     for import_expression in ignore_imports or []:
@@ -132,6 +109,10 @@ def _remove_ignored_imports(
         removed_imports=frozenset(imports_to_remove),
         warnings=tuple(resolved_warnings),
     )
+
+
+# Private functions
+# -----------------
 
 
 def _handle_unresolved_import_expressions(

--- a/src/importlinter/application/contract_utils.py
+++ b/src/importlinter/application/contract_utils.py
@@ -17,7 +17,7 @@ def remove_ignored_imports(
     graph: ImportGraph,
     ignore_imports: Sequence[ImportExpression] | None,
     unmatched_alerting: AlertLevel,
-) -> list[str]:
+) -> tuple[list[str], int]:
     """
     Remove any ignored imports from the graph.
 
@@ -30,7 +30,10 @@ def remove_ignored_imports(
                             a MissingImport with all unmatched imports.
 
     Returns:
-        A list of any warnings to be surfaced to the user.
+        A tuple of:
+            - A list of any warnings to be surfaced to the user.
+            - The number of individual imports that were removed from the graph (the size
+              of the imports_to_remove set).
     """
     imports_to_remove = set()
     unresolved_expressions = []
@@ -63,7 +66,7 @@ def remove_ignored_imports(
             imported=import_to_remove.imported.name,
         )
 
-    return warnings
+    return warnings, len(imports_to_remove)
 
 
 # Private functions

--- a/src/importlinter/application/contract_utils.py
+++ b/src/importlinter/application/contract_utils.py
@@ -1,5 +1,7 @@
 import enum
+import warnings
 from collections.abc import Sequence
+from dataclasses import dataclass
 
 
 from importlinter.domain.helpers import MissingImport
@@ -13,11 +15,69 @@ class AlertLevel(enum.Enum):
     ERROR = "error"
 
 
+@dataclass(frozen=True)
+class ImportRemoval:
+    """
+    The result of removing a set of ignored imports from a graph.
+    """
+
+    removed_imports: frozenset[DirectImport]
+    warnings: tuple[str, ...]
+
+    @property
+    def ignored_import_count(self) -> int:
+        """
+        The number of distinct (importer, imported) pairs that were removed from the graph.
+
+        This is the size of removed_imports, not a count of raw import statements or of
+        ignore_imports entries matched: an (importer, imported) pair that corresponds to
+        multiple import statements (e.g. several lines in the same module) is still counted
+        once.
+        """
+        return len(self.removed_imports)
+
+
 def remove_ignored_imports(
     graph: ImportGraph,
     ignore_imports: Sequence[ImportExpression] | None,
     unmatched_alerting: AlertLevel,
-) -> tuple[list[str], int]:
+) -> list[str]:
+    """
+    Remove any ignored imports from the graph.
+
+    Deprecated: this function's return type will change from list[str] to ImportRemoval in
+    Import Linter 2.15. New callers, and existing callers who are able to, should switch to
+    remove_ignored_imports_and_report, which already returns an ImportRemoval today. This
+    function will keep returning a plain list of warnings until that release, but emits a
+    DeprecationWarning as of this release to flag the upcoming change.
+
+    Args:
+        graph:              The graph that is being checked by a contract.
+        ignore_imports:     Any import expressions that indicate imports to ignore.
+        unmatched_alerting: An AlertLevel that indicates how to handle any import expressions that
+                            don't match any imports. AlertLevel.NONE will ignore them,
+                            AlertLevel.WARN will warn for each one, and AlertLevel.ERROR will raise
+                            a MissingImport with all unmatched imports.
+
+    Returns:
+        A list of any warnings to be surfaced to the user.
+    """
+    warnings.warn(
+        "remove_ignored_imports() will change its return type from list[str] to ImportRemoval "
+        "in Import Linter 2.15. Switch to remove_ignored_imports_and_report(), which already "
+        "returns an ImportRemoval, to be ready ahead of that change.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    import_removal = _remove_ignored_imports(graph, ignore_imports, unmatched_alerting)
+    return list(import_removal.warnings)
+
+
+def remove_ignored_imports_and_report(
+    graph: ImportGraph,
+    ignore_imports: Sequence[ImportExpression] | None,
+    unmatched_alerting: AlertLevel,
+) -> ImportRemoval:
     """
     Remove any ignored imports from the graph.
 
@@ -30,12 +90,22 @@ def remove_ignored_imports(
                             a MissingImport with all unmatched imports.
 
     Returns:
-        A tuple of:
-            - A list of any warnings to be surfaced to the user.
-            - The number of individual imports that were removed from the graph (the size
-              of the imports_to_remove set).
+        An ImportRemoval, containing the DirectImports that were removed from the graph and any
+        warnings to be surfaced to the user.
     """
-    imports_to_remove = set()
+    return _remove_ignored_imports(graph, ignore_imports, unmatched_alerting)
+
+
+# Private functions
+# -----------------
+
+
+def _remove_ignored_imports(
+    graph: ImportGraph,
+    ignore_imports: Sequence[ImportExpression] | None,
+    unmatched_alerting: AlertLevel,
+) -> ImportRemoval:
+    imports_to_remove: set[DirectImport] = set()
     unresolved_expressions = []
     for import_expression in ignore_imports or []:
         matched_imports = graph.find_matching_direct_imports(
@@ -55,7 +125,7 @@ def remove_ignored_imports(
             if import_expression not in unresolved_expressions:
                 unresolved_expressions.append(import_expression)
 
-    warnings = _handle_unresolved_import_expressions(
+    resolved_warnings = _handle_unresolved_import_expressions(
         unresolved_expressions,
         unmatched_alerting,
     )
@@ -66,11 +136,10 @@ def remove_ignored_imports(
             imported=import_to_remove.imported.name,
         )
 
-    return warnings, len(imports_to_remove)
-
-
-# Private functions
-# -----------------
+    return ImportRemoval(
+        removed_imports=frozenset(imports_to_remove),
+        warnings=tuple(resolved_warnings),
+    )
 
 
 def _handle_unresolved_import_expressions(

--- a/src/importlinter/application/contract_utils.py
+++ b/src/importlinter/application/contract_utils.py
@@ -26,14 +26,6 @@ class ImportRemoval:
 
     @property
     def ignored_import_count(self) -> int:
-        """
-        The number of distinct (importer, imported) pairs that were removed from the graph.
-
-        This is the size of removed_imports, not a count of raw import statements or of
-        ignore_imports entries matched: an (importer, imported) pair that corresponds to
-        multiple import statements (e.g. several lines in the same module) is still counted
-        once.
-        """
         return len(self.removed_imports)
 
 

--- a/src/importlinter/application/rendering.py
+++ b/src/importlinter/application/rendering.py
@@ -88,10 +88,7 @@ def render_contract_result_line(
     color = output.COLORS[color_key]
     output.print(f"{contract.name} ", newline=False)
     output.print(result_text, color=color, newline=False)
-    if warnings_count:
-        output.print(result_suffix_text, color=output.COLORS[output.WARNING], newline=False)
-    else:
-        output.print(result_suffix_text, newline=False)
+    output.print(result_suffix_text, color=output.COLORS[output.WARNING], newline=False)
     if duration is not None:
         output.print(f" [{format_duration(duration)}]", newline=False)
     output.new_line()

--- a/src/importlinter/application/rendering.py
+++ b/src/importlinter/application/rendering.py
@@ -79,11 +79,15 @@ def render_contract_result_line(
                   The duration will only be displayed if it is provided.
     """
     result_text = "KEPT" if contract_check.kept else "BROKEN"
+    ignored_imports_text = _build_ignored_imports_text(
+        ignored_import_count=contract_check.ignored_import_count
+    )
     warning_text = _build_warning_text(warnings_count=len(contract_check.warnings))
     color_key = output.SUCCESS if contract_check.kept else output.ERROR
     color = output.COLORS[color_key]
     output.print(f"{contract.name} ", newline=False)
     output.print(result_text, color=color, newline=False)
+    output.print(ignored_imports_text, newline=False)
     output.print(warning_text, color=output.COLORS[output.WARNING], newline=False)
     if duration is not None:
         output.print(f" [{format_duration(duration)}]", newline=False)
@@ -113,6 +117,14 @@ def _build_warning_text(warnings_count: int) -> str:
     if warnings_count:
         noun = "warning" if warnings_count == 1 else "warnings"
         return f" ({warnings_count} {noun})"
+    else:
+        return ""
+
+
+def _build_ignored_imports_text(ignored_import_count: int) -> str:
+    if ignored_import_count:
+        noun = "import" if ignored_import_count == 1 else "imports"
+        return f" ({ignored_import_count} ignored {noun})"
     else:
         return ""
 

--- a/src/importlinter/application/rendering.py
+++ b/src/importlinter/application/rendering.py
@@ -79,16 +79,19 @@ def render_contract_result_line(
                   The duration will only be displayed if it is provided.
     """
     result_text = "KEPT" if contract_check.kept else "BROKEN"
-    ignored_imports_text = _build_ignored_imports_text(
-        ignored_import_count=contract_check.ignored_import_count
+    warnings_count = len(contract_check.warnings)
+    result_suffix_text = _build_result_suffix_text(
+        ignored_import_count=contract_check.ignored_import_count,
+        warnings_count=warnings_count,
     )
-    warning_text = _build_warning_text(warnings_count=len(contract_check.warnings))
     color_key = output.SUCCESS if contract_check.kept else output.ERROR
     color = output.COLORS[color_key]
     output.print(f"{contract.name} ", newline=False)
     output.print(result_text, color=color, newline=False)
-    output.print(ignored_imports_text, newline=False)
-    output.print(warning_text, color=output.COLORS[output.WARNING], newline=False)
+    if warnings_count:
+        output.print(result_suffix_text, color=output.COLORS[output.WARNING], newline=False)
+    else:
+        output.print(result_suffix_text, newline=False)
     if duration is not None:
         output.print(f" [{format_duration(duration)}]", newline=False)
     output.new_line()
@@ -113,18 +116,26 @@ def _render_could_not_run(report: Report) -> None:
             output.print_error(f"{field_name}: {message}", bold=False)
 
 
-def _build_warning_text(warnings_count: int) -> str:
-    if warnings_count:
-        noun = "warning" if warnings_count == 1 else "warnings"
-        return f" ({warnings_count} {noun})"
-    else:
-        return ""
+def _build_result_suffix_text(ignored_import_count: int, warnings_count: int) -> str:
+    """
+    Build the "(...)" suffix that follows a contract's KEPT/BROKEN result, combining the
+    ignored imports count and the warnings count into a single clause, e.g.:
 
-
-def _build_ignored_imports_text(ignored_import_count: int) -> str:
+        My contract KEPT
+        My contract KEPT (19 ignored imports)
+        My contract KEPT (1 warning)
+        My contract KEPT (19 ignored imports, 1 warning)
+    """
+    parts = []
     if ignored_import_count:
         noun = "import" if ignored_import_count == 1 else "imports"
-        return f" ({ignored_import_count} ignored {noun})"
+        parts.append(f"{ignored_import_count} ignored {noun}")
+    if warnings_count:
+        noun = "warning" if warnings_count == 1 else "warnings"
+        parts.append(f"{warnings_count} {noun}")
+
+    if parts:
+        return f" ({', '.join(parts)})"
     else:
         return ""
 

--- a/src/importlinter/contracts/acyclic_siblings.py
+++ b/src/importlinter/contracts/acyclic_siblings.py
@@ -48,7 +48,7 @@ class AcyclicSiblingsContract(Contract):
         descendants_to_skip = self._get_concrete_skipped_descendants(graph)
         depth: int = self.depth  # type: ignore
 
-        warnings = contract_utils.remove_ignored_imports(
+        warnings, ignored_import_count = contract_utils.remove_ignored_imports(
             graph=graph,
             ignore_imports=self.ignore_imports,  # type: ignore
             unmatched_alerting=self.unmatched_ignore_imports_alerting,  # type: ignore
@@ -65,6 +65,7 @@ class AcyclicSiblingsContract(Contract):
         return ContractCheck(
             kept=not bool(cycle_breakers_by_package),
             warnings=warnings,
+            ignored_import_count=ignored_import_count,
             metadata={
                 "cycle_breakers_by_package": cycle_breakers_by_package,
                 "summaries": self._build_summaries(cycle_breakers_by_package),

--- a/src/importlinter/contracts/acyclic_siblings.py
+++ b/src/importlinter/contracts/acyclic_siblings.py
@@ -48,7 +48,7 @@ class AcyclicSiblingsContract(Contract):
         descendants_to_skip = self._get_concrete_skipped_descendants(graph)
         depth: int = self.depth  # type: ignore
 
-        warnings, ignored_import_count = contract_utils.remove_ignored_imports(
+        import_removal = contract_utils.remove_ignored_imports_and_report(
             graph=graph,
             ignore_imports=self.ignore_imports,  # type: ignore
             unmatched_alerting=self.unmatched_ignore_imports_alerting,  # type: ignore
@@ -64,8 +64,8 @@ class AcyclicSiblingsContract(Contract):
 
         return ContractCheck(
             kept=not bool(cycle_breakers_by_package),
-            warnings=warnings,
-            ignored_import_count=ignored_import_count,
+            warnings=list(import_removal.warnings),
+            ignored_import_count=import_removal.ignored_import_count,
             metadata={
                 "cycle_breakers_by_package": cycle_breakers_by_package,
                 "summaries": self._build_summaries(cycle_breakers_by_package),

--- a/src/importlinter/contracts/forbidden.py
+++ b/src/importlinter/contracts/forbidden.py
@@ -77,7 +77,7 @@ class ForbiddenContract(Contract):
         is_kept = True
         invalid_chains = []
 
-        warnings = contract_utils.remove_ignored_imports(
+        warnings, ignored_import_count = contract_utils.remove_ignored_imports(
             graph=graph,
             ignore_imports=self.ignore_imports,  # type: ignore
             unmatched_alerting=self.unmatched_ignore_imports_alerting,  # type: ignore
@@ -178,6 +178,7 @@ class ForbiddenContract(Contract):
         return ContractCheck(
             kept=is_kept,
             warnings=warnings,
+            ignored_import_count=ignored_import_count,
             metadata={"invalid_chains": sorted(invalid_chains, key=chain_sort_key)},
         )
 

--- a/src/importlinter/contracts/forbidden.py
+++ b/src/importlinter/contracts/forbidden.py
@@ -77,7 +77,7 @@ class ForbiddenContract(Contract):
         is_kept = True
         invalid_chains = []
 
-        warnings, ignored_import_count = contract_utils.remove_ignored_imports(
+        import_removal = contract_utils.remove_ignored_imports_and_report(
             graph=graph,
             ignore_imports=self.ignore_imports,  # type: ignore
             unmatched_alerting=self.unmatched_ignore_imports_alerting,  # type: ignore
@@ -177,8 +177,8 @@ class ForbiddenContract(Contract):
 
         return ContractCheck(
             kept=is_kept,
-            warnings=warnings,
-            ignored_import_count=ignored_import_count,
+            warnings=list(import_removal.warnings),
+            ignored_import_count=import_removal.ignored_import_count,
             metadata={"invalid_chains": sorted(invalid_chains, key=chain_sort_key)},
         )
 

--- a/src/importlinter/contracts/independence.py
+++ b/src/importlinter/contracts/independence.py
@@ -52,7 +52,7 @@ class IndependenceContract(Contract):
     unmatched_ignore_imports_alerting = fields.EnumField(AlertLevel, default=AlertLevel.ERROR)
 
     def check(self, graph: ImportGraph, verbose: bool) -> ContractCheck:
-        warnings = contract_utils.remove_ignored_imports(
+        warnings, ignored_import_count = contract_utils.remove_ignored_imports(
             graph=graph,
             ignore_imports=self.ignore_imports,  # type: ignore
             unmatched_alerting=self.unmatched_ignore_imports_alerting,  # type: ignore
@@ -70,6 +70,7 @@ class IndependenceContract(Contract):
         return ContractCheck(
             kept=not dependencies,
             warnings=warnings,
+            ignored_import_count=ignored_import_count,
             metadata={"invalid_chains": invalid_chains},
         )
 

--- a/src/importlinter/contracts/independence.py
+++ b/src/importlinter/contracts/independence.py
@@ -52,7 +52,7 @@ class IndependenceContract(Contract):
     unmatched_ignore_imports_alerting = fields.EnumField(AlertLevel, default=AlertLevel.ERROR)
 
     def check(self, graph: ImportGraph, verbose: bool) -> ContractCheck:
-        warnings, ignored_import_count = contract_utils.remove_ignored_imports(
+        import_removal = contract_utils.remove_ignored_imports_and_report(
             graph=graph,
             ignore_imports=self.ignore_imports,  # type: ignore
             unmatched_alerting=self.unmatched_ignore_imports_alerting,  # type: ignore
@@ -69,8 +69,8 @@ class IndependenceContract(Contract):
 
         return ContractCheck(
             kept=not dependencies,
-            warnings=warnings,
-            ignored_import_count=ignored_import_count,
+            warnings=list(import_removal.warnings),
+            ignored_import_count=import_removal.ignored_import_count,
             metadata={"invalid_chains": invalid_chains},
         )
 

--- a/src/importlinter/contracts/layers.py
+++ b/src/importlinter/contracts/layers.py
@@ -141,7 +141,7 @@ class LayersContract(Contract):
             )
 
     def check(self, graph: grimp.ImportGraph, verbose: bool) -> ContractCheck:
-        warnings, ignored_import_count = contract_utils.remove_ignored_imports(
+        import_removal = contract_utils.remove_ignored_imports_and_report(
             graph=graph,
             ignore_imports=self.ignore_imports,  # type: ignore
             unmatched_alerting=self.unmatched_ignore_imports_alerting,  # type: ignore
@@ -168,8 +168,8 @@ class LayersContract(Contract):
 
         return ContractCheck(
             kept=not (dependencies or undeclared_modules),
-            warnings=warnings,
-            ignored_import_count=ignored_import_count,
+            warnings=list(import_removal.warnings),
+            ignored_import_count=import_removal.ignored_import_count,
             metadata={
                 "invalid_dependencies": invalid_chains,
                 "undeclared_modules": undeclared_modules,

--- a/src/importlinter/contracts/layers.py
+++ b/src/importlinter/contracts/layers.py
@@ -141,7 +141,7 @@ class LayersContract(Contract):
             )
 
     def check(self, graph: grimp.ImportGraph, verbose: bool) -> ContractCheck:
-        warnings = contract_utils.remove_ignored_imports(
+        warnings, ignored_import_count = contract_utils.remove_ignored_imports(
             graph=graph,
             ignore_imports=self.ignore_imports,  # type: ignore
             unmatched_alerting=self.unmatched_ignore_imports_alerting,  # type: ignore
@@ -169,6 +169,7 @@ class LayersContract(Contract):
         return ContractCheck(
             kept=not (dependencies or undeclared_modules),
             warnings=warnings,
+            ignored_import_count=ignored_import_count,
             metadata={
                 "invalid_dependencies": invalid_chains,
                 "undeclared_modules": undeclared_modules,

--- a/src/importlinter/contracts/protected.py
+++ b/src/importlinter/contracts/protected.py
@@ -42,7 +42,7 @@ class ProtectedContract(Contract):
     as_packages = fields.BooleanField(required=False, default=True)
 
     def check(self, graph: grimp.ImportGraph, verbose: bool) -> ContractCheck:
-        warnings, ignored_import_count = contract_utils.remove_ignored_imports(
+        import_removal = contract_utils.remove_ignored_imports_and_report(
             graph=graph,
             ignore_imports=self.ignore_imports,  # type: ignore
             unmatched_alerting=self.unmatched_ignore_imports_alerting,  # type: ignore
@@ -113,8 +113,8 @@ class ProtectedContract(Contract):
 
         return ContractCheck(
             kept=not bool(illegal_imports_metadata),
-            warnings=warnings,
-            ignored_import_count=ignored_import_count,
+            warnings=list(import_removal.warnings),
+            ignored_import_count=import_removal.ignored_import_count,
             metadata={"illegal_imports": illegal_imports_metadata},
         )
 

--- a/src/importlinter/contracts/protected.py
+++ b/src/importlinter/contracts/protected.py
@@ -42,7 +42,7 @@ class ProtectedContract(Contract):
     as_packages = fields.BooleanField(required=False, default=True)
 
     def check(self, graph: grimp.ImportGraph, verbose: bool) -> ContractCheck:
-        warnings = contract_utils.remove_ignored_imports(
+        warnings, ignored_import_count = contract_utils.remove_ignored_imports(
             graph=graph,
             ignore_imports=self.ignore_imports,  # type: ignore
             unmatched_alerting=self.unmatched_ignore_imports_alerting,  # type: ignore
@@ -114,6 +114,7 @@ class ProtectedContract(Contract):
         return ContractCheck(
             kept=not bool(illegal_imports_metadata),
             warnings=warnings,
+            ignored_import_count=ignored_import_count,
             metadata={"illegal_imports": illegal_imports_metadata},
         )
 

--- a/src/importlinter/domain/contract.py
+++ b/src/importlinter/domain/contract.py
@@ -110,10 +110,12 @@ class ContractCheck:
         kept: bool,
         metadata: dict[str, Any] | None = None,
         warnings: list[str] | None = None,
+        ignored_import_count: int = 0,
     ) -> None:
         self.kept = kept
         self.metadata = metadata or {}
         self.warnings = warnings or []
+        self.ignored_import_count = ignored_import_count
 
 
 class NoSuchContractType(Exception):

--- a/tests/helpers/contracts.py
+++ b/tests/helpers/contracts.py
@@ -7,9 +7,14 @@ from importlinter.domain.contract import Contract, ContractCheck
 
 class AlwaysPassesContract(Contract):
     warnings = fields.ListField(subfield=fields.StringField(), required=False)
+    ignored_import_count = fields.IntegerField(required=False)
 
     def check(self, graph: ImportGraph, verbose: bool) -> ContractCheck:
-        return ContractCheck(kept=True, warnings=self.warnings)  # type: ignore
+        return ContractCheck(
+            kept=True,
+            warnings=self.warnings,  # type: ignore
+            ignored_import_count=self.ignored_import_count or 0,  # type: ignore
+        )
 
     def render_broken_contract(self, check: "ContractCheck") -> None:
         # No need to implement, will never fail.

--- a/tests/unit/application/test_contract_utils.py
+++ b/tests/unit/application/test_contract_utils.py
@@ -15,6 +15,146 @@ from importlinter.domain.imports import (
 )
 
 
+class TestRemoveIgnoredImports:
+    DIRECT_IMPORTS = [
+        DirectImport(
+            importer=Module("mypackage.green"),
+            imported=Module("mypackage.yellow"),
+            line_number=1,
+            line_contents="-",
+        ),
+        DirectImport(
+            importer=Module("mypackage.green"),
+            imported=Module("mypackage.purple"),
+            line_number=1,
+            line_contents="-",
+        ),
+        DirectImport(
+            importer=Module("mypackage.green"),
+            imported=Module("mypackage.blue"),
+            line_number=1,
+            line_contents="-",
+        ),
+        DirectImport(  # Direct Imports can appear twice, for different line numbers.
+            importer=Module("mypackage.green"),
+            imported=Module("mypackage.blue"),
+            line_number=2,
+            line_contents="-",
+        ),
+    ]
+
+    @pytest.mark.parametrize("alert_level", [AlertLevel.NONE, AlertLevel.WARN, AlertLevel.ERROR])
+    def test_no_unresolved_import_expressions(self, alert_level):
+        graph = self._build_graph(self.DIRECT_IMPORTS)
+
+        warnings = remove_ignored_imports(
+            graph=graph,
+            ignore_imports=[
+                ImportExpression(
+                    importer=ModuleExpression("mypackage.green"),
+                    imported=ModuleExpression("mypackage.blue"),
+                ),
+                ImportExpression(
+                    importer=ModuleExpression("mypackage.green"),
+                    imported=ModuleExpression("mypackage.purple"),
+                ),
+            ],
+            unmatched_alerting=alert_level,
+        )
+
+        assert graph.count_imports() == 1  # The three matching imports have been removed.
+        assert warnings == []
+
+    @pytest.mark.parametrize(
+        "alert_level, expected_result",
+        [
+            (AlertLevel.NONE, []),
+            (
+                AlertLevel.WARN,
+                [
+                    "No matches for ignored import mypackage.* -> mypackage.nonexistent.",
+                    "No matches for ignored import mypackage.nonexistent -> mypackage.blue.",
+                ],
+            ),
+        ],
+    )
+    def test_unresolved_import_expressions_with_non_error_level_alerting(
+        self, alert_level, expected_result
+    ):
+        graph = self._build_graph(self.DIRECT_IMPORTS)
+        ignore_imports = [
+            ImportExpression(
+                importer=ModuleExpression("mypackage.green"),
+                imported=ModuleExpression("mypackage.blue"),
+            ),
+            ImportExpression(
+                importer=ModuleExpression("mypackage.*"),
+                imported=ModuleExpression("mypackage.nonexistent"),
+            ),
+            ImportExpression(
+                importer=ModuleExpression("mypackage.green"),
+                imported=ModuleExpression("mypackage.purple"),
+            ),
+            ImportExpression(
+                importer=ModuleExpression("mypackage.nonexistent"),
+                imported=ModuleExpression("mypackage.blue"),
+            ),
+        ]
+
+        warnings = remove_ignored_imports(
+            graph=graph,
+            ignore_imports=ignore_imports,
+            unmatched_alerting=alert_level,
+        )
+        assert graph.count_imports() == 1  # The three matching imports have been removed.
+        assert warnings == expected_result
+
+    def test_unresolved_import_expressions_with_error_level_alerting(self):
+        graph = self._build_graph(self.DIRECT_IMPORTS)
+
+        expected_result = MissingImport(
+            "No matches for ignored import mypackage.* -> mypackage.nonexistent.\n"
+            "No matches for ignored import mypackage.nonexistent -> mypackage.blue."
+        )
+
+        ignore_imports = [
+            ImportExpression(
+                importer=ModuleExpression("mypackage.green"),
+                imported=ModuleExpression("mypackage.blue"),
+            ),
+            ImportExpression(
+                importer=ModuleExpression("mypackage.*"),
+                imported=ModuleExpression("mypackage.nonexistent"),
+            ),
+            ImportExpression(
+                importer=ModuleExpression("mypackage.green"),
+                imported=ModuleExpression("mypackage.purple"),
+            ),
+            ImportExpression(
+                importer=ModuleExpression("mypackage.nonexistent"),
+                imported=ModuleExpression("mypackage.blue"),
+            ),
+        ]
+
+        with pytest.raises(MissingImport, match=str(expected_result)):
+            remove_ignored_imports(
+                graph=graph,
+                ignore_imports=ignore_imports,
+                unmatched_alerting=AlertLevel.ERROR,
+            )
+
+    def _build_graph(self, direct_imports):
+        graph = ImportGraph()
+        for direct_import in direct_imports:
+            graph.add_import(
+                importer=direct_import.importer.name,
+                imported=direct_import.imported.name,
+                line_number=direct_import.line_number,
+                line_contents=direct_import.line_contents,
+            )
+        return graph
+
+
 class TestRemoveIgnoredImportsAndReport:
     DIRECT_IMPORTS = [
         DirectImport(
@@ -174,67 +314,3 @@ class TestRemoveIgnoredImportsAndReport:
                 line_contents=direct_import.line_contents,
             )
         return graph
-
-
-class TestRemoveIgnoredImportsDeprecated:
-    """
-    remove_ignored_imports() is deprecated in favour of remove_ignored_imports_and_report(),
-    but keeps its old behaviour (returning a plain list of warning strings) until Import
-    Linter 2.15. These tests only cover the deprecation shim; see
-    TestRemoveIgnoredImportsAndReport above for full coverage of the underlying behaviour.
-    """
-
-    def _build_graph(self):
-        graph = ImportGraph()
-        graph.add_import(
-            importer="mypackage.green",
-            imported="mypackage.blue",
-            line_number=1,
-            line_contents="-",
-        )
-        return graph
-
-    def test_emits_deprecation_warning(self):
-        graph = self._build_graph()
-
-        with pytest.warns(DeprecationWarning, match="remove_ignored_imports_and_report"):
-            remove_ignored_imports(
-                graph=graph,
-                ignore_imports=[],
-                unmatched_alerting=AlertLevel.ERROR,
-            )
-
-    def test_still_returns_a_plain_list_of_warnings(self):
-        graph = self._build_graph()
-
-        with pytest.warns(DeprecationWarning):
-            warnings = remove_ignored_imports(
-                graph=graph,
-                ignore_imports=[
-                    ImportExpression(
-                        importer=ModuleExpression("mypackage.*"),
-                        imported=ModuleExpression("mypackage.nonexistent"),
-                    ),
-                ],
-                unmatched_alerting=AlertLevel.WARN,
-            )
-
-        assert isinstance(warnings, list)
-        assert warnings == ["No matches for ignored import mypackage.* -> mypackage.nonexistent."]
-
-    def test_still_removes_matching_imports_from_the_graph(self):
-        graph = self._build_graph()
-
-        with pytest.warns(DeprecationWarning):
-            remove_ignored_imports(
-                graph=graph,
-                ignore_imports=[
-                    ImportExpression(
-                        importer=ModuleExpression("mypackage.green"),
-                        imported=ModuleExpression("mypackage.blue"),
-                    ),
-                ],
-                unmatched_alerting=AlertLevel.ERROR,
-            )
-
-        assert graph.count_imports() == 0

--- a/tests/unit/application/test_contract_utils.py
+++ b/tests/unit/application/test_contract_utils.py
@@ -43,7 +43,7 @@ class TestRemoveIgnoredImports:
     def test_no_unresolved_import_expressions(self, alert_level):
         graph = self._build_graph(self.DIRECT_IMPORTS)
 
-        warnings = remove_ignored_imports(
+        warnings, ignored_import_count = remove_ignored_imports(
             graph=graph,
             ignore_imports=[
                 ImportExpression(
@@ -60,6 +60,9 @@ class TestRemoveIgnoredImports:
 
         assert graph.count_imports() == 1  # The three matching imports have been removed.
         assert warnings == []
+        # Two distinct (importer, imported) pairs were removed (green->blue, green->purple),
+        # even though green->blue accounted for two individual import statements.
+        assert ignored_import_count == 2
 
     @pytest.mark.parametrize(
         "alert_level, expected_result",
@@ -97,13 +100,16 @@ class TestRemoveIgnoredImports:
             ),
         ]
 
-        warnings = remove_ignored_imports(
+        warnings, ignored_import_count = remove_ignored_imports(
             graph=graph,
             ignore_imports=ignore_imports,
             unmatched_alerting=alert_level,
         )
         assert graph.count_imports() == 1  # The three matching imports have been removed.
         assert warnings == expected_result
+        # Two distinct (importer, imported) pairs were removed (green->blue, green->purple);
+        # the two unresolved expressions don't contribute to the count.
+        assert ignored_import_count == 2
 
     def test_unresolved_import_expressions_with_error_level_alerting(self):
         graph = self._build_graph(self.DIRECT_IMPORTS)

--- a/tests/unit/application/test_contract_utils.py
+++ b/tests/unit/application/test_contract_utils.py
@@ -1,7 +1,11 @@
 import pytest
 from grimp import ImportGraph
 
-from importlinter.application.contract_utils import AlertLevel, remove_ignored_imports
+from importlinter.application.contract_utils import (
+    AlertLevel,
+    remove_ignored_imports,
+    remove_ignored_imports_and_report,
+)
 from importlinter.domain.helpers import MissingImport
 from importlinter.domain.imports import (
     DirectImport,
@@ -11,7 +15,7 @@ from importlinter.domain.imports import (
 )
 
 
-class TestRemoveIgnoredImports:
+class TestRemoveIgnoredImportsAndReport:
     DIRECT_IMPORTS = [
         DirectImport(
             importer=Module("mypackage.green"),
@@ -43,7 +47,7 @@ class TestRemoveIgnoredImports:
     def test_no_unresolved_import_expressions(self, alert_level):
         graph = self._build_graph(self.DIRECT_IMPORTS)
 
-        warnings, ignored_import_count = remove_ignored_imports(
+        import_removal = remove_ignored_imports_and_report(
             graph=graph,
             ignore_imports=[
                 ImportExpression(
@@ -59,21 +63,31 @@ class TestRemoveIgnoredImports:
         )
 
         assert graph.count_imports() == 1  # The three matching imports have been removed.
-        assert warnings == []
+        assert import_removal.warnings == ()
         # Two distinct (importer, imported) pairs were removed (green->blue, green->purple),
         # even though green->blue accounted for two individual import statements.
-        assert ignored_import_count == 2
+        assert import_removal.ignored_import_count == 2
+        assert import_removal.removed_imports == frozenset(
+            {
+                DirectImport(
+                    importer=Module("mypackage.green"), imported=Module("mypackage.blue")
+                ),
+                DirectImport(
+                    importer=Module("mypackage.green"), imported=Module("mypackage.purple")
+                ),
+            }
+        )
 
     @pytest.mark.parametrize(
         "alert_level, expected_result",
         [
-            (AlertLevel.NONE, []),
+            (AlertLevel.NONE, ()),
             (
                 AlertLevel.WARN,
-                [
+                (
                     "No matches for ignored import mypackage.* -> mypackage.nonexistent.",
                     "No matches for ignored import mypackage.nonexistent -> mypackage.blue.",
-                ],
+                ),
             ),
         ],
     )
@@ -100,19 +114,20 @@ class TestRemoveIgnoredImports:
             ),
         ]
 
-        warnings, ignored_import_count = remove_ignored_imports(
+        import_removal = remove_ignored_imports_and_report(
             graph=graph,
             ignore_imports=ignore_imports,
             unmatched_alerting=alert_level,
         )
         assert graph.count_imports() == 1  # The three matching imports have been removed.
-        assert warnings == expected_result
+        assert import_removal.warnings == expected_result
         # Two distinct (importer, imported) pairs were removed (green->blue, green->purple);
         # the two unresolved expressions don't contribute to the count.
-        assert ignored_import_count == 2
+        assert import_removal.ignored_import_count == 2
 
     def test_unresolved_import_expressions_with_error_level_alerting(self):
         graph = self._build_graph(self.DIRECT_IMPORTS)
+        import_count_before = graph.count_imports()
 
         expected_result = MissingImport(
             "No matches for ignored import mypackage.* -> mypackage.nonexistent.\n"
@@ -139,11 +154,15 @@ class TestRemoveIgnoredImports:
         ]
 
         with pytest.raises(MissingImport, match=str(expected_result)):
-            remove_ignored_imports(
+            remove_ignored_imports_and_report(
                 graph=graph,
                 ignore_imports=ignore_imports,
                 unmatched_alerting=AlertLevel.ERROR,
             )
+
+        # Nothing should have been removed from the graph: an ERROR-level unmatched
+        # expression aborts the whole operation before any removal happens.
+        assert graph.count_imports() == import_count_before
 
     def _build_graph(self, direct_imports):
         graph = ImportGraph()
@@ -155,3 +174,67 @@ class TestRemoveIgnoredImports:
                 line_contents=direct_import.line_contents,
             )
         return graph
+
+
+class TestRemoveIgnoredImportsDeprecated:
+    """
+    remove_ignored_imports() is deprecated in favour of remove_ignored_imports_and_report(),
+    but keeps its old behaviour (returning a plain list of warning strings) until Import
+    Linter 2.15. These tests only cover the deprecation shim; see
+    TestRemoveIgnoredImportsAndReport above for full coverage of the underlying behaviour.
+    """
+
+    def _build_graph(self):
+        graph = ImportGraph()
+        graph.add_import(
+            importer="mypackage.green",
+            imported="mypackage.blue",
+            line_number=1,
+            line_contents="-",
+        )
+        return graph
+
+    def test_emits_deprecation_warning(self):
+        graph = self._build_graph()
+
+        with pytest.warns(DeprecationWarning, match="remove_ignored_imports_and_report"):
+            remove_ignored_imports(
+                graph=graph,
+                ignore_imports=[],
+                unmatched_alerting=AlertLevel.ERROR,
+            )
+
+    def test_still_returns_a_plain_list_of_warnings(self):
+        graph = self._build_graph()
+
+        with pytest.warns(DeprecationWarning):
+            warnings = remove_ignored_imports(
+                graph=graph,
+                ignore_imports=[
+                    ImportExpression(
+                        importer=ModuleExpression("mypackage.*"),
+                        imported=ModuleExpression("mypackage.nonexistent"),
+                    ),
+                ],
+                unmatched_alerting=AlertLevel.WARN,
+            )
+
+        assert isinstance(warnings, list)
+        assert warnings == ["No matches for ignored import mypackage.* -> mypackage.nonexistent."]
+
+    def test_still_removes_matching_imports_from_the_graph(self):
+        graph = self._build_graph()
+
+        with pytest.warns(DeprecationWarning):
+            remove_ignored_imports(
+                graph=graph,
+                ignore_imports=[
+                    ImportExpression(
+                        importer=ModuleExpression("mypackage.green"),
+                        imported=ModuleExpression("mypackage.blue"),
+                    ),
+                ],
+                unmatched_alerting=AlertLevel.ERROR,
+            )
+
+        assert graph.count_imports() == 0

--- a/tests/unit/application/test_rendering.py
+++ b/tests/unit/application/test_rendering.py
@@ -1,6 +1,54 @@
 import pytest
+from grimp import ImportGraph
 
 from importlinter.application import rendering
+from importlinter.application.output import console
+from tests.helpers.contracts import AlwaysFailsContract, AlwaysPassesContract
+
+
+class TestRenderContractResultLine:
+    """
+    Covers the "(...)" suffix that follows a contract's KEPT/BROKEN result: the ignored
+    imports count and the warnings count, combined into a single clause.
+    """
+
+    @pytest.mark.parametrize(
+        "ignored_import_count, warning_messages, expected_line",
+        [
+            (0, [], "My contract KEPT"),
+            (19, [], "My contract KEPT (19 ignored imports)"),
+            (1, [], "My contract KEPT (1 ignored import)"),
+            (0, ["A warning."], "My contract KEPT (1 warning)"),
+            (0, ["One.", "Two."], "My contract KEPT (2 warnings)"),
+            (19, ["A warning."], "My contract KEPT (19 ignored imports, 1 warning)"),
+        ],
+    )
+    def test_kept_contract(self, ignored_import_count, warning_messages, expected_line):
+        contract = AlwaysPassesContract(
+            name="My contract",
+            session_options={},
+            contract_options={
+                "ignored_import_count": ignored_import_count,
+                "warnings": warning_messages,
+            },
+        )
+        contract_check = contract.check(ImportGraph(), verbose=False)
+
+        with console.capture() as capture:
+            rendering.render_contract_result_line(contract, contract_check, duration=None)
+
+        assert capture.get() == f"{expected_line}\n"
+
+    def test_broken_contract_with_no_ignored_imports_or_warnings(self):
+        contract = AlwaysFailsContract(
+            name="My contract", session_options={}, contract_options={}
+        )
+        contract_check = contract.check(ImportGraph(), verbose=False)
+
+        with console.capture() as capture:
+            rendering.render_contract_result_line(contract, contract_check, duration=None)
+
+        assert capture.get() == "My contract BROKEN\n"
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/application/test_rendering.py
+++ b/tests/unit/application/test_rendering.py
@@ -40,9 +40,7 @@ class TestRenderContractResultLine:
         assert capture.get() == f"{expected_line}\n"
 
     def test_broken_contract_with_no_ignored_imports_or_warnings(self):
-        contract = AlwaysFailsContract(
-            name="My contract", session_options={}, contract_options={}
-        )
+        contract = AlwaysFailsContract(name="My contract", session_options={}, contract_options={})
         contract_check = contract.check(ImportGraph(), verbose=False)
 
         with console.capture() as capture:


### PR DESCRIPTION
Fixes #375.

Implements the ignored-imports count exactly as specified in the issue thread:

- No new CLI flag -- always shown in the contract result line.
- Omitted when a contract has zero ignored imports.
- The count is the size of the `imports_to_remove` set in `remove_ignored_imports` (distinct importer/imported pairs actually removed from the graph), not a count of raw import statements or of `ignore_imports` entries matched.

Example output:

    Independence KEPT (1 ignored import)

- [x] Add tests for the change.
- [x] Add any appropriate documentation.
- [ ] Run `just check`.
- [x] Add a summary of changes to `docs/release_notes.md`.
- [x] Add your name to `docs/authors.md` (in alphabetical order).

I don't have `just` set up locally, so instead I ran the relevant unit tests directly: `pytest tests/unit/application/test_contract_utils.py tests/unit/application/test_use_cases.py tests/unit/contracts/` -- all passing.