### PR TITLE
Update github actions to silence warnings about Node 20

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,10 +17,10 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Install just
-        uses: extractions/setup-just@v3
+        uses: extractions/setup-just@v4
 
       - name: Install uv and set the Python version
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v7
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -40,10 +40,10 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Install just
-        uses: extractions/setup-just@v3
+        uses: extractions/setup-just@v4
 
       - name: Install uv and set the Python version
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v7
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -66,7 +66,7 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Install uv and set the Python version
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v7
 
       - name: Smoke test lint-imports
         run: uv run lint-imports
@@ -85,10 +85,10 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Install just
-        uses: extractions/setup-just@v3
+        uses: extractions/setup-just@v4
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v7
 
       - name: Build docs
         run: just build-docs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v7
       - name: Build a binary wheel and a source tarball
         run: "uv run --with=build python -m build --sdist --wheel --outdir dist/"
       - name: Publish to PyPI


### PR DESCRIPTION
Prior to this, the github actions were emitting warnings about Node.js 20 being deprecated. 